### PR TITLE
Shadow Dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Elements can be read form the python side using dictionary notation, for example
 
 Changes made from the Python side occur on the Tcl side, and all accesses, traversals, etc, are made using the Tcl array.  In other words, ShadowDicts never cache values from the Tcl array on the python side.
 
-In the example below we set up a Tcl array, create a ShadowDict of it in python, get a string representation of the dict, read from the dict, insert into it, delete from it, and demonstrate that the changes we made are present on the Tcl side.
+In the example below we set up a Tcl array, create a ShadowDict of it in python, get a string representation of the dict, read from the dict, insert into it, delete from it, and demonstrate that the changes we made are present on the Tcl side.  Finally, it iterates over the shadow dict, showing the same keys from python that tcl was shown to have.
 
 ```
 >>> tohil.eval("array set x [list a 1 b 2 c 3 d 4]")
@@ -220,6 +220,13 @@ x(b) = 2
 x(c) = 3
 x(e) = 5
 ''
+>>> for i in x:
+...     print(i)
+...
+a
+b
+c
+e
 ```
 
 #### Examples using tohil from Python

--- a/README.md
+++ b/README.md
@@ -186,6 +186,42 @@ Tcl's *subst* command is pretty cool.  By default it performs Tcl backslash, com
 
 Although we could easily make tohil.subst support the "to=" way of request a type conversion, is there any case where you wouldn't just expect it to return a string?
 
+#### Shadow Dictionaries
+
+Shadow Dictionaries, aka ShadowDicts, create a python dict-like object that shadows a Tcl array.
+
+Tcl arrays are kind of the Tcl equivalent of Python's dicts, by the way.
+
+Anyway, let's assume we have an array "x" in Tcl that we want to shadow as a dictionary "x" in Python, we would write `x = tohil.ShadowDict("x")`
+
+Once created, the shadowdict can be gotten as a string using str() or print(), etc.
+
+Elements can be read form the python side using dictionary notation, for example `x['d']`, set in a standard way (`x['e'] = '5'`), and deleted using del (`del x['e']`).  Also you can iterate on the keys as with dicts.
+
+Changes made from the Python side occur on the Tcl side, and all accesses, traversals, etc, are made using the Tcl array.  In other words, ShadowDicts never cache values from the Tcl array on the python side.
+
+In the example below we set up a Tcl array, create a ShadowDict of it in python, get a string representation of the dict, read from the dict, insert into it, delete from it, and demonstrate that the changes we made are present on the Tcl side.
+
+```
+>>> tohil.eval("array set x [list a 1 b 2 c 3 d 4]")
+''
+>>> x = tohil.ShadowDict("x")
+>>> x
+{'d': '4', 'e': '5', 'a': '1', 'b': '2', 'c': '3'}
+>>> x['d']
+'4'
+>>> x['e'] = '5'
+>>> x['e']
+'5'
+>>> del x['d']            
+>>> tohil.eval("parray x")
+x(a) = 1
+x(b) = 2
+x(c) = 3
+x(e) = 5
+''
+```
+
 #### Examples using tohil from Python
 
 ```python

--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -26,6 +26,8 @@ from tohil._tohil import (
 
 from tohil.tcller import TclWriter
 
+from tohil.shadowdict import ShadowDict
+
 
 class RivetControl:
     """probably lame stuff to redirect python stdout to tcl,

--- a/pysrc/tohil/shadowdict.py
+++ b/pysrc/tohil/shadowdict.py
@@ -1,0 +1,43 @@
+
+
+from collections.abc import MutableMapping
+
+import tohil
+
+class ShadowDictIterator():
+    def __init__(self, tcl_array):
+        self.keys = tohil.eval(f"array names {tcl_array}", to=list)
+        self.keys.sort()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if len(self.keys) == 0:
+            raise StopIteration
+
+        return self.keys.pop(0)
+
+class ShadowDict(MutableMapping):
+    def __init__(self, tcl_array):
+        self.tcl_array = tcl_array
+
+    def __getitem__(self, key):
+        return tohil.getvar(f"{self.tcl_array}({key})")
+
+    def __delitem__(self, key):
+        tohil.unset(f"{self.tcl_array}({key})")
+        return
+
+    def __setitem__(self, key, value):
+        tohil.setvar(f"self.{self.tcl_array}({key})", value)
+
+    def __len__(self):
+        return tohil.eval(f"array size {self.tcl_array}")
+
+    def __repr__(self):
+        return str(tohil.eval(f"array get {self.tcl_array}", to=dict))
+
+    def __iter__(self):
+        return ShadowDictIterator(self.tcl_array)
+

--- a/pysrc/tohil/shadowdict.py
+++ b/pysrc/tohil/shadowdict.py
@@ -33,7 +33,7 @@ class ShadowDict(MutableMapping):
         tohil.setvar(f"{self.tcl_array}({key})", value)
 
     def __len__(self):
-        return tohil.eval(f"array size {self.tcl_array}")
+        return tohil.eval(f"array size {self.tcl_array}", to=int)
 
     def __repr__(self):
         return str(tohil.eval(f"array get {self.tcl_array}", to=dict))

--- a/pysrc/tohil/shadowdict.py
+++ b/pysrc/tohil/shadowdict.py
@@ -41,3 +41,5 @@ class ShadowDict(MutableMapping):
     def __iter__(self):
         return ShadowDictIterator(self.tcl_array)
 
+    def __contains__(self, key):
+        return tohil.exists(f"{self.tcl_array}({key})")

--- a/pysrc/tohil/shadowdict.py
+++ b/pysrc/tohil/shadowdict.py
@@ -30,7 +30,7 @@ class ShadowDict(MutableMapping):
         return
 
     def __setitem__(self, key, value):
-        tohil.setvar(f"self.{self.tcl_array}({key})", value)
+        tohil.setvar(f"{self.tcl_array}({key})", value)
 
     def __len__(self):
         return tohil.eval(f"array size {self.tcl_array}")


### PR DESCRIPTION
Shadow Dictionaries, aka ShadowDicts, create a python dict-like object that shadows a Tcl array.

Assume we have an array "x" in Tcl that we want to shadow as a dictionary "x" in Python, we would write `x = tohil.ShadowDict("x")`

Once created, the shadowdict can be gotten as a string using str() or print(), etc.

Elements can be read form the python side using dictionary notation, for example `x['d']`, set in a standard way (`x['e'] = '5'`), and deleted using del (`del x['e']`).  Also you can iterate on the keys as with dicts.

Changes made from the Python side occur on the Tcl side, and all accesses, traversals, etc, are made using the Tcl array.  In other words, ShadowDicts never cache values from the Tcl array on the python side.
