### PR TITLE
td_iterator method is an iterator over tclobj tcl dicts

### DIFF
--- a/TCLOBJECTS.md
+++ b/TCLOBJECTS.md
@@ -99,6 +99,22 @@ x = t.td_get(['a','b','c'], to=tohil.tclobj)
 
 Likewise you can compose a more complicated dictionaries by attaching a dictionary to a point within another dictionary, simply by doing a td_set with the value being a tclobj that itself contains a dictionary.
 
+#### TD iterators
+
+You can iterate over a TD with td_iter. For example, something like:
+
+```
+t = tohil.tclobj("a 1 b 2 c 3 d 4 e 5 f 6")
+for i in t.td_iter():
+    print(i)
+```
+
+If you pass a to= conversion to td_iter, the iterator returns tuples comprising the key and the value as well, with the value converted to the to= conversion.
+
+```
+for key, value in t.td_iter(to=int):
+    print(f"key {key} value {value}")
+```
 
 ### misc stuff
 

--- a/tests/test_td_iter.py
+++ b/tests/test_td_iter.py
@@ -1,0 +1,22 @@
+
+
+import unittest
+
+import tohil
+
+from tohil import tclobj
+
+class Test_td_iter(unittest.TestCase):
+    def test_td_iter1(self):
+        """tohil.tclobj td_iter """
+        t = tohil.tclobj("a 1 b 2 c 3 d 4 e 5 f 6")
+        self.assertEqual(list(t.td_iter()), ['a', 'b', 'c', 'd', 'e', 'f'])
+
+    def test_td_iter2(self):
+        """tohil.tclobj td_iter with to= conversion """
+        t = tohil.tclobj("a 1 b 2 c 3 d 4 e 5 f 6")
+        self.assertEqual(list(t.td_iter(to=int)), [('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5), ('f', 6)])
+        self.assertEqual(list(t.td_iter(to=str)), [('a', '1'), ('b', '2'), ('c', '3'), ('d', '4'), ('e', '5'), ('f', '6')])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
You can now iterate over a TD with td_iter. For example, something like:

```
t = tohil.tclobj("a 1 b 2 c 3 d 4 e 5 f 6")
for i in t.td_iter():
    print(i)
```

If you pass a to= conversion to td_iter, the iterator returns tuples comprising the key and the value as well, with the value converted to the to= conversion.

```
for key, value in t.td_iter(to=int):
    print(f"key {key} value {value}")
```