### PR TITLE
to= option for tclobj and tcldict object creation, setting "to" as a member of those objects

### DIFF
--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1714,7 +1714,7 @@ PyTclObj_slice(PyTclObj *self, Py_ssize_t ilow, Py_ssize_t ihigh)
     for (i = 0; i < len; i++) {
         // create a new tclobj object and store
         // it into the python list we are making
-        PyObject *v = PyTclObj_FromTclObj(src[i]);
+        PyObject *v = tohil_python_return(tcl_interp, TCL_OK, self->to, src[i]);
         PyList_SET_ITEM(np, i, v);
     }
     return (PyObject *)np;
@@ -1743,7 +1743,7 @@ PyTclObj_item(PyTclObj *self, Py_ssize_t i)
         return NULL;
     }
 
-    PyObject *ret = PyTclObj_FromTclObj(listObjv[i]);
+    PyObject *ret = tohil_python_return(tcl_interp, TCL_OK, self->to, listObjv[i]);
     Py_INCREF(ret);
     return ret;
 }
@@ -1827,7 +1827,7 @@ PyTclObj_subscript(PyTclObj *self, PyObject *item)
             PyErr_SetString(PyExc_TypeError, Tcl_GetString(Tcl_GetObjResult(tcl_interp)));
             return NULL;
         }
-        return PyTclObj_FromTclObj(resultObj);
+        return tohil_python_return(tcl_interp, TCL_OK, self->to, resultObj);
     } else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelength, i;
         size_t cur;
@@ -1841,7 +1841,7 @@ PyTclObj_subscript(PyTclObj *self, PyObject *item)
         slicelength = PySlice_AdjustIndices(size, &start, &stop, step);
 
         if (slicelength <= 0) {
-            return PyTclObj_FromTclObj(Tcl_NewObj());
+            return tohil_python_return(tcl_interp, TCL_OK, self->to, Tcl_NewObj());
         } else if (step == 1) {
             return PyTclObj_slice(self, start, stop);
         } else {
@@ -1858,7 +1858,7 @@ PyTclObj_subscript(PyTclObj *self, PyObject *item)
             }
 
             for (cur = start, i = 0; i < slicelength; cur += (size_t)step, i++) {
-                it = PyTclObj_FromTclObj(listObjv[cur]);
+                it = tohil_python_return(tcl_interp, TCL_OK, self->to, listObjv[cur]);
                 PyList_SET_ITEM(result, i, it);
             }
             return result;

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2031,6 +2031,32 @@ PyTohil_TD_td_iter(PyTclObj *self, PyObject *args, PyObject *kwargs)
 //
 //
 
+static PyObject *
+PyTclObj_getto(PyTclObj *self, void *closure)
+{
+    if (self->to == NULL) {
+        Py_RETURN_NONE;
+    }
+    Py_INCREF(self->to);
+    return (PyObject *)self->to;
+}
+
+static int
+PyTclObj_setto(PyTclObj *self, PyTypeObject *toType, void *closure)
+{
+    if (!PyType_Check(toType)) {
+        return -1;
+    }
+    PyTypeObject *tmp = self->to;
+    self->to = toType;
+    Py_INCREF(toType);
+    Py_XDECREF(tmp);
+    return 0;
+}
+
+static PyGetSetDef PyTclObj_getsetters[] = {{"to", (getter)PyTclObj_getto, (setter)PyTclObj_setto, "python type to default returns to", NULL},
+                                            {NULL}};
+
 static PyMappingMethods PyTclObj_as_mapping = {(lenfunc)PyTclObj_length, (binaryfunc)PyTclObj_subscript, NULL};
 
 static PySequenceMethods PyTclObj_as_sequence = {
@@ -2093,6 +2119,7 @@ static PyTypeObject PyTclObjType = {
     .tp_as_mapping = &PyTclObj_as_mapping,
     .tp_repr = (reprfunc)PyTclObj_repr,
     .tp_richcompare = (richcmpfunc)PyTclObj_richcompare,
+    .tp_getset = PyTclObj_getsetters,
 };
 
 //

--- a/tests/test_tcldict.py
+++ b/tests/test_tcldict.py
@@ -44,8 +44,8 @@ class TestTcleDict(unittest.TestCase):
 
         self.assertEqual(str(d), 'a 1 b 2 c 3 d 4 m {i i1 j j1 k k1}')
 
-        self.assertEqual(d.td_get(['m', 'k']), 'k1')
-        self.assertEqual(d.td_get('m'), 'i i1 j j1 k k1')
+        self.assertEqual(d.get(['m', 'k']), 'k1')
+        self.assertEqual(d.get('m'), 'i i1 j j1 k k1')
         self.assertEqual(len(d), 5)
         self.assertEqual(len(e), 3)
 

--- a/tests/test_tclobj.py
+++ b/tests/test_tclobj.py
@@ -73,6 +73,8 @@ class TestTclObj(unittest.TestCase):
         """exercise tohil.tclobj subscripting, str(), and repr()"""
         x = tohil.eval("list 1 2 3 4 5", to=tohil.tclobj)
         self.assertEqual(str(x[2]), "3")
+        self.assertEqual(repr(x[2]), "'3'")
+        x.to = tohil.tclobj
         self.assertEqual(repr(x[2]), "<tohil.tclobj: '3'>")
 
     def test_tclobj11(self):
@@ -93,6 +95,11 @@ class TestTclObj(unittest.TestCase):
         """tohil.tclobj slice stuff, 4 to the end"""
         x = tohil.eval("list 1 2 3 4 5 6 7", to=tohil.tclobj)
         self.assertEqual(
+            x[4:],
+            ['5', '6', '7'],
+        )
+        x.to = tohil.tclobj
+        self.assertEqual(
             repr(x[4:]),
             "[<tohil.tclobj: '5'>, <tohil.tclobj: '6'>, <tohil.tclobj: '7'>]",
         )
@@ -100,6 +107,11 @@ class TestTclObj(unittest.TestCase):
     def test_tclobj14(self):
         """tohil.tclobj slice stuff, the beginning until 4"""
         x = tohil.eval("list 1 2 3 4 5 6 7", to=tohil.tclobj)
+        self.assertEqual(
+            x[:4],
+            ['1', '2', '3', '4'],
+        )
+        x.to = tohil.tclobj
         self.assertEqual(
             repr(x[:4]),
             "[<tohil.tclobj: '1'>, <tohil.tclobj: '2'>, <tohil.tclobj: '3'>, <tohil.tclobj: '4'>]",
@@ -109,6 +121,16 @@ class TestTclObj(unittest.TestCase):
         """tohil.tclobj slice stuff, from the beginning to 4 from the end"""
         x = tohil.eval("list 1 2 3 4 5 6 7", to=tohil.tclobj)
         self.assertEqual(
+            x[:-4],
+            ['1', '2', '3'],
+        )
+        x.to = int
+        self.assertEqual(
+            x[:-4],
+            [1, 2, 3],
+        )
+        x.to = tohil.tclobj
+        self.assertEqual(
             repr(x[:-4]),
             "[<tohil.tclobj: '1'>, <tohil.tclobj: '2'>, <tohil.tclobj: '3'>]",
         )
@@ -116,6 +138,11 @@ class TestTclObj(unittest.TestCase):
     def test_tclobj16(self):
         """tohil.tclobj slice stuff, from 4 from the end to the end"""
         x = tohil.eval("list 1 2 3 4 5 6 7", to=tohil.tclobj)
+        self.assertEqual(
+            x[-4:],
+            ['4', '5', '6', '7'],
+        )
+        x.to = tohil.tclobj
         self.assertEqual(
             repr(x[-4:]),
             "[<tohil.tclobj: '4'>, <tohil.tclobj: '5'>, <tohil.tclobj: '6'>, <tohil.tclobj: '7'>]",
@@ -125,6 +152,16 @@ class TestTclObj(unittest.TestCase):
         """tohil.tclobj slice stuff, the whole thing with a :"""
         x = tohil.eval("list 1 2 3 4 5 6 7", to=tohil.tclobj)
         self.assertEqual(
+            x[:],
+            ['1', '2', '3', '4', '5', '6', '7'],
+        )
+        x.to = float
+        self.assertEqual(
+            x[:],
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+        )
+        x.to = tohil.tclobj
+        self.assertEqual(
             repr(x[:]),
             "[<tohil.tclobj: '1'>, <tohil.tclobj: '2'>, <tohil.tclobj: '3'>, <tohil.tclobj: '4'>, <tohil.tclobj: '5'>, <tohil.tclobj: '6'>, <tohil.tclobj: '7'>]",
         )
@@ -133,8 +170,11 @@ class TestTclObj(unittest.TestCase):
         """tohil.tclobj comparing tclobjs with stuff"""
         x = tohil.eval("list 1 2 3 4 5 6 7", to=tohil.tclobj)
         self.assertTrue(x[2] == x[2])
+        x.to = int
         self.assertTrue(x[2] == 3)
+        x.to = str
         self.assertTrue(x[2] == "3")
+        x.to = float
         self.assertTrue(x[2] < 4.0)
         self.assertFalse(x[2] > 4.0)
 


### PR DESCRIPTION
Allow tclobj and tcldict types to accept an option to=type parameter at object creation type, and provide a "to" member that can be get and set, obj.to=str, etc, to one of our accepted datatypes.  This is cool.