### PR TITLE
More tclobj

### DIFF
--- a/KNOTES.md
+++ b/KNOTES.md
@@ -207,4 +207,49 @@ python3-ipython
 
 crap, valtype::imei is both a namespace and a proc
 
+---
+
+need an equivalent to ShadowDicts for scalar variables in tcl
+
+the problem is if it's a class then you don't have any keen assignment
+syntax, unlike with shadow dicts; you're going to have to invoke a function
+because if you say `foo = tohil.ShadowVar("foo")` that's good but you can't
+say `foo = 'bar'` to assign to it because that'll create a new foo.
+
+you'll have to do like foo.set('bar'), which is a bit annoying.
+
+also the class can be callable so you could get it with foo()
+
+and it could reconigze it was called with an argument and could set from that
+
+
+
+analysis = tohil.ShadowVar("analysis")
+
+analysis.set(analysis() + 'foo')
+
+wish we could say analysis += message
+
+that's not too hard actually
+
+we could even make tclobj's += look at the argument and if it's a string use
+concatenation, although we might ought to look at that string as a number,
+we do now, and just stick with that, i don't know.
+
+we've got these tclobjs and they're pretty handy already.  maybe the trick
+is to provide a way to bind a tclobj to a tcl variable so that when read it
+reattaches the tclobj to the var if it doesn't exactly point at it
+
+and after stores a Tcl_ObjSetVar2, or whatever, to keep the var synced
+with the object.
+
+analysis = tohil.tclobj(var="analysis")
+
+we already have t.setvar() and t.getvar() to manually sync
+
+
+
+
+
+
 

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so that we create the export library with the dll.
 #-----------------------------------------------------------------------
 
-AC_INIT([tohil],[3.1.2])
+AC_INIT([tohil],[3.2.0])
 
 #--------------------------------------------------------------------
 # Call TEA_INIT as the first TEA_ macro to set up initial vars.

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1890,7 +1890,7 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             return PyFloat_FromDouble(floor(doubleV / doubleW));
 
         case Remainder:
-            return PyFloat_FromDouble(fmod(doubleV, doubleW));
+            return PyFloat_FromDouble(fmod(fmod(doubleV, doubleW) + doubleW, doubleW));
 
         case Divmod:
             quotient = doubleV / doubleW;
@@ -1937,7 +1937,7 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             return PyLong_FromLong(ldiv_res.quot);
 
         case Remainder:
-            return PyLong_FromLong(longV % longW);
+            return PyLong_FromLong(((longV % longW) + longW) % longW);
 
 
         case Divmod:

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2095,7 +2095,7 @@ tclobj_inplace_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             break;
 
         case Remainder:
-            Tcl_SetDoubleObj(self->tclobj, fmod(doubleV, doubleW));
+            Tcl_SetDoubleObj(self->tclobj, fmod(fmod(doubleV, doubleW) + doubleW, doubleW));
             break;
 
         case Truediv:
@@ -2156,7 +2156,7 @@ tclobj_inplace_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             break;
 
         case Remainder:
-            Tcl_SetLongObj(self->tclobj, longV % longW);
+            Tcl_SetLongObj(self->tclobj, ((longV % longW) + longW) % longW);
             break;
 
         default:

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2247,15 +2247,16 @@ static PyNumberMethods tclobj_as_number = {
     .nb_positive = (unaryfunc)tclobj_positive,
     .nb_absolute = (unaryfunc)tclobj_absolute,
     .nb_invert = (unaryfunc)tclobj_invert,
+
     .nb_inplace_add = tclobj_inplace_add,
     .nb_inplace_subtract = tclobj_inplace_subtract,
     .nb_inplace_multiply = tclobj_inplace_multiply,
     .nb_inplace_remainder = tclobj_inplace_remainder,
+    .nb_inplace_lshift = tclobj_inplace_lshift,
+    .nb_inplace_rshift = tclobj_inplace_rshift,
     .nb_inplace_and = tclobj_inplace_and,
     .nb_inplace_or = tclobj_inplace_or,
     .nb_inplace_xor = tclobj_inplace_xor,
-    .nb_inplace_lshift = tclobj_inplace_lshift,
-    .nb_inplace_rshift = tclobj_inplace_rshift,
 };
 
 //

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1843,7 +1843,7 @@ tclobj_unaryop(PyObject *v, enum tclobj_unary_op operator)
     }
 }
 
-enum tclobj_op { Add, Sub, Mul, And, Or, Xor, Lshift, Rshift, Remainder, Divmod };
+enum tclobj_op { Add, Sub, Mul, And, Or, Xor, Lshift, Rshift, Remainder, Divmod, Truediv };
 
 static PyObject *
 tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
@@ -1883,6 +1883,9 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
         case Mul:
             return PyFloat_FromDouble(doubleV * doubleW);
 
+        case Truediv:
+            return PyFloat_FromDouble(doubleV / doubleW);
+
         case Remainder:
             return PyFloat_FromDouble(fmod(doubleV, doubleW));
 
@@ -1920,6 +1923,9 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
         case Rshift:
             return PyLong_FromLong(longV >> longW);
 
+        case Truediv:
+            return PyFloat_FromDouble((double)longV / (double)longW);
+
         case Remainder:
             return PyLong_FromLong(longV % longW);
 
@@ -1946,6 +1952,12 @@ static PyObject *
 tclobj_multiply(PyObject *v, PyObject *w)
 {
     return tclobj_binop(v, w, Mul);
+}
+
+static PyObject *
+tclobj_true_divide(PyObject *v, PyObject *w)
+{
+    return tclobj_binop(v, w, Truediv);
 }
 
 static PyObject *
@@ -2170,6 +2182,7 @@ static PyNumberMethods tclobj_as_number = {
     .nb_add = tclobj_add,
     .nb_subtract = tclobj_subtract,
     .nb_multiply = tclobj_multiply,
+    .nb_true_divide = tclobj_true_divide,
     .nb_remainder = tclobj_remainder,
     .nb_divmod = tclobj_divmod,
     .nb_and = tclobj_and,

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1843,7 +1843,7 @@ tclobj_unaryop(PyObject *v, enum tclobj_unary_op operator)
     }
 }
 
-enum tclobj_op { Add, Sub, Mul, And, Or, Xor, Lshift, Rshift, Remainder, Divmod, Truediv };
+enum tclobj_op { Add, Sub, Mul, And, Or, Xor, Lshift, Rshift, Remainder, Divmod, Truediv, Floordiv };
 
 static PyObject *
 tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
@@ -1886,6 +1886,9 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
         case Truediv:
             return PyFloat_FromDouble(doubleV / doubleW);
 
+        case Floordiv:
+            return PyFloat_FromDouble(floor(doubleV / doubleW));
+
         case Remainder:
             return PyFloat_FromDouble(fmod(doubleV, doubleW));
 
@@ -1926,8 +1929,12 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
         case Truediv:
             return PyFloat_FromDouble((double)longV / (double)longW);
 
+        case Floordiv:
+            return PyLong_FromLong((long)longV / (long)longW);
+
         case Remainder:
             return PyLong_FromLong(longV % longW);
+
 
         case Divmod:
             ldiv_res = ldiv(longV, longW);
@@ -1958,6 +1965,12 @@ static PyObject *
 tclobj_true_divide(PyObject *v, PyObject *w)
 {
     return tclobj_binop(v, w, Truediv);
+}
+
+static PyObject *
+tclobj_floor_divide(PyObject *v, PyObject *w)
+{
+    return tclobj_binop(v, w, Floordiv);
 }
 
 static PyObject *
@@ -2202,6 +2215,7 @@ static PyNumberMethods tclobj_as_number = {
     .nb_subtract = tclobj_subtract,
     .nb_multiply = tclobj_multiply,
     .nb_true_divide = tclobj_true_divide,
+    .nb_floor_divide = tclobj_floor_divide,
     .nb_remainder = tclobj_remainder,
     .nb_divmod = tclobj_divmod,
     .nb_and = tclobj_and,

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1364,6 +1364,16 @@ TohilTclObj_refcount(TohilTclObj *self, PyObject *dummy)
 }
 
 //
+// TohilTclObj_pyrefcount - return the python reference count of the
+//   tclobj or tcldict object
+//
+static PyObject *
+TohilTclObj_pyrefcount(TohilTclObj *self, PyObject *dummy)
+{
+    return PyLong_FromLong(Py_REFCNT(self));
+}
+
+//
 // TohilTclObj_type - return the internal tcl data type of
 //   the corresponding tclobj/tcldict python type
 //
@@ -2360,6 +2370,7 @@ TohilTclObj_setto(TohilTclObj *self, PyTypeObject *toType, void *closure)
 static PyGetSetDef TohilTclObj_getsetters[] = {
     {"to", (getter)TohilTclObj_getto, (setter)TohilTclObj_setto, "python type to default returns to", NULL},
     {"_refcount", (getter)TohilTclObj_refcount, NULL, "reference count of the embedded tcl object", NULL},
+    {"_pyrefcount", (getter)TohilTclObj_pyrefcount, NULL, "python reference count of the tcl object", NULL},
     {"_tcltype", (getter)TohilTclObj_type, NULL, "internal tcl data type of the tcl object", NULL},
     {NULL}};
 

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1015,72 +1015,6 @@ TohilTclObj_reset(TohilTclObj *self, PyObject *pyobj)
 }
 
 //
-// tclobj.as_int()
-//
-static PyObject *
-TohilTclObj_as_int(TohilTclObj *self, PyObject *pyobj)
-{
-    long longValue;
-
-    if (Tcl_GetLongFromObj(self->interp, self->tclobj, &longValue) == TCL_OK) {
-        return PyLong_FromLong(longValue);
-    }
-    PyErr_SetString(PyExc_TypeError, Tcl_GetString(Tcl_GetObjResult(self->interp)));
-    return NULL;
-}
-
-//
-// tclobj.as_float()
-//
-static PyObject *
-TohilTclObj_as_float(TohilTclObj *self, PyObject *pyobj)
-{
-    double doubleValue;
-
-    if (Tcl_GetDoubleFromObj(self->interp, self->tclobj, &doubleValue) == TCL_OK) {
-        return PyFloat_FromDouble(doubleValue);
-    }
-    PyErr_SetString(PyExc_TypeError, Tcl_GetString(Tcl_GetObjResult(self->interp)));
-    return NULL;
-}
-
-//
-// tclobj.as_bool()
-//
-static PyObject *
-TohilTclObj_as_bool(TohilTclObj *self, PyObject *pyobj)
-{
-    int intValue;
-    if (Tcl_GetBooleanFromObj(self->interp, self->tclobj, &intValue) == TCL_OK) {
-        PyObject *p = (intValue ? Py_True : Py_False);
-        Py_INCREF(p);
-        return p;
-    }
-    PyErr_SetString(PyExc_TypeError, Tcl_GetString(Tcl_GetObjResult(self->interp)));
-    return NULL;
-}
-
-//
-// tclobj.as_string()
-//
-static PyObject *
-TohilTclObj_as_string(TohilTclObj *self, PyObject *pyobj)
-{
-    int tclStringSize;
-    char *tclString = Tcl_GetStringFromObj(self->tclobj, &tclStringSize);
-
-    int utf8len;
-    char *utf8string;
-    if (tohil_TclToUTF8(tclString, tclStringSize, &utf8string, &utf8len) != TCL_OK) {
-        PyErr_SetString(PyExc_RuntimeError, Tcl_GetString(Tcl_GetObjResult(self->interp)));
-        return NULL;
-    }
-    PyObject *pObj = Py_BuildValue("s#", utf8string, utf8len);
-    ckfree(utf8string);
-    return pObj;
-}
-
-//
 // tclobj.as_list()
 //
 static PyObject *
@@ -2311,12 +2245,7 @@ static PySequenceMethods TohilTclObj_as_sequence = {
 
 static PyMethodDef TohilTclObj_methods[] = {
     {"__getitem__", (PyCFunction)TohilTclObj_subscript, METH_O | METH_COEXIST, "x.__getitem__(y) <==> x[y]"},
-    {"__bool__", (PyCFunction)TohilTclObj_as_bool, METH_NOARGS, "return tclobj as bool"},
     {"reset", (PyCFunction)TohilTclObj_reset, METH_NOARGS, "reset the tclobj"},
-    {"as_str", (PyCFunction)TohilTclObj_as_string, METH_NOARGS, "return tclobj as str"},
-    {"as_int", (PyCFunction)TohilTclObj_as_int, METH_NOARGS, "return tclobj as int"},
-    {"as_float", (PyCFunction)TohilTclObj_as_float, METH_NOARGS, "return tclobj as float"},
-    {"as_bool", (PyCFunction)TohilTclObj_as_bool, METH_NOARGS, "return tclobj as bool"},
     {"as_list", (PyCFunction)TohilTclObj_as_list, METH_NOARGS, "return tclobj as list"},
     {"as_set", (PyCFunction)TohilTclObj_as_set, METH_NOARGS, "return tclobj as set"},
     {"as_tuple", (PyCFunction)TohilTclObj_as_tuple, METH_NOARGS, "return tclobj as tuple"},

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1907,7 +1907,7 @@ tclobj_unaryop(PyObject *v, enum tclobj_unary_op operator)
     }
 }
 
-enum tclobj_op { Add, Sub, Mul, And, Or, Xor, Lshift, Rshift };
+enum tclobj_op { Add, Sub, Mul, And, Or, Xor, Lshift, Rshift, Remainder };
 
 static PyObject *
 tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
@@ -1943,6 +1943,9 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
         case Mul:
             return PyFloat_FromDouble(doubleV * doubleW);
 
+        case Remainder:
+            return PyFloat_FromDouble(fmod(doubleV, doubleW));
+
         default:
             Py_RETURN_NOTIMPLEMENTED;
         }
@@ -1971,6 +1974,9 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
 
         case Rshift:
             return PyLong_FromLong(longV >> longW);
+
+        case Remainder:
+            return PyLong_FromLong(longV % longW);
         }
     }
 }
@@ -1991,6 +1997,12 @@ static PyObject *
 tclobj_multiply(PyObject *v, PyObject *w)
 {
     return tclobj_binop(v, w, Mul);
+}
+
+static PyObject *
+tclobj_remainder(PyObject *v, PyObject *w)
+{
+    return tclobj_binop(v, w, Remainder);
 }
 
 static PyObject *
@@ -2054,6 +2066,7 @@ static PyNumberMethods tclobj_as_number = {
     .nb_add = tclobj_add,
     .nb_subtract = tclobj_subtract,
     .nb_multiply = tclobj_multiply,
+    .nb_remainder = tclobj_remainder,
     .nb_and = tclobj_and,
     .nb_or = tclobj_or,
     .nb_xor = tclobj_xor,

--- a/tests/test_tclobj.py
+++ b/tests/test_tclobj.py
@@ -206,6 +206,34 @@ class TestTclObj(unittest.TestCase):
             t.set("foo")
             t.incr()
 
+    def test_tclobj21(self):
+        """tohil.tclobj numer type 'boolean' tests"""
+        self.assertEqual(bool(tohil.tclobj('f')), False)
+        self.assertEqual(bool(tohil.tclobj('F')), False)
+        self.assertEqual(bool(tohil.tclobj('n')), False)
+        self.assertEqual(bool(tohil.tclobj('N')), False)
+        self.assertEqual(bool(tohil.tclobj('0')), False)
+        self.assertEqual(bool(tohil.tclobj('t')), True)
+        self.assertEqual(bool(tohil.tclobj('T')), True)
+        self.assertEqual(bool(tohil.tclobj('y')), True)
+        self.assertEqual(bool(tohil.tclobj('Y')), True)
+        self.assertEqual(bool(tohil.tclobj('1')), True)
+        with self.assertRaises(TypeError):
+            bool(tohil.tclobj('foo'))
+
+    def test_tclobj22(self):
+        """tohil.tclobj numer type 'int' tests"""
+        self.assertEqual(int(tohil.tclobj('5')), 5)
+        self.assertEqual(int(tohil.tclobj(5)), 5)
+        self.assertEqual(int(tohil.tclobj('5.0')), 5)
+        self.assertEqual(int(tohil.tclobj(5.0)), 5)
+
+    def test_tclobj23(self):
+        """tohil.tclobj numer type 'float' tests"""
+        self.assertEqual(float(tohil.tclobj('5')), 5.0)
+        self.assertEqual(float(tohil.tclobj(5)), 5.0)
+        self.assertEqual(float(tohil.tclobj('5.0')), 5.0)
+        self.assertEqual(float(tohil.tclobj(5.0)), 5.0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tclobj.py
+++ b/tests/test_tclobj.py
@@ -52,9 +52,9 @@ class TestTclObj(unittest.TestCase):
         """exercise tohil.tclobj as_tuple()"""
         x = tohil.expr("5", to=tohil.tclobj)
 
-        self.assertEqual(x.as_int(), 5)
-        self.assertEqual(x.as_float(), 5.0)
-        self.assertEqual(x.as_bool(), True)
+        self.assertEqual(int(x), 5)
+        self.assertEqual(float(x), 5.0)
+        self.assertEqual(bool(x), True)
 
     def test_tclobj8(self):
         """exercise tohil.tclobj setvar()"""

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -67,8 +67,8 @@ class TestTclObj(unittest.TestCase):
         self.assertEqual(-6. * t, -36.)
 
     def test_tclobj_math6(self):
-        """exercise tohil.tclobj remainder math ops"""
-        t = tohil.tclobj(9)
+        """exercise tohil.tclobj remainder ops"""
+        t = tohil.tclobj(1)
 
         self.assertEqual(t % 7, 2)
         self.assertEqual(11 % t, 2)
@@ -78,6 +78,75 @@ class TestTclObj(unittest.TestCase):
         self.assertEqual(-7 % 9, 2)
         self.assertEqual(t % t, 0)
         self.assertEqual(-6. % t, 3)
+
+    def test_tclobj_math7(self):
+        """exercise tohil.tclobj left shift math ops"""
+        t = tohil.tclobj(2)
+
+        self.assertEqual(t << 4, 32)
+        self.assertEqual(t << t, 8)
+        self.assertEqual(16 << 2, 64)
+
+    def test_tclobj_math8(self):
+        """exercise tohil.tclobj right shift math ops"""
+        t = tohil.tclobj(8)
+
+        self.assertEqual(t >> 1, 4)
+        self.assertEqual(t >> t, 0)
+        self.assertEqual(65536 >> t, 256)
+
+    def test_tclobj_math9(self):
+        """exercise tohil.tclobj "and" math ops"""
+        t = tohil.tclobj(31)
+
+        self.assertEqual(t & 16, 16)
+        self.assertEqual(t & t, 31)
+        self.assertEqual(8 & t, 8)
+
+    def test_tclobj_math10(self):
+        """exercise tohil.tclobj "or" math ops"""
+        t = tohil.tclobj(16)
+
+        self.assertEqual(t | 8, 24)
+        self.assertEqual(4 | t, 20)
+        self.assertEqual(t | t, 16)
+
+    def test_tclobj_math11(self):
+        """exercise tohil.tclobj "or" math ops"""
+        t = tohil.tclobj(31)
+
+        self.assertEqual(t ^ 15, 16)
+        self.assertEqual(15 ^ t, 16)
+        self.assertEqual(t ^ t, 0)
+
+    def test_tclobj_math12(self):
+        """exercise tohil.tclobj "inplace add" math ops"""
+        t = tohil.tclobj(7)
+        t5 = tohil.tclobj(5)
+
+        t += 5
+        self.assertEqual(t, 12)
+        t += t
+        self.assertEqual(t, 24)
+        t += t5
+        self.assertEqual(t, 29)
+        t5 += t
+        self.assertEqual(t5, 34)
+
+    def test_tclobj_math13(self):
+        """exercise tohil.tclobj "inplace subtract" math ops"""
+        t = tohil.tclobj(7)
+        t5 = tohil.tclobj(5)
+
+        t -= -1
+        self.assertEqual(t, 8)
+        t -= t
+        self.assertEqual(t, 0)
+        t -= t5
+        self.assertEqual(t, -5)
+        t5 -= t
+        self.assertEqual(t5, 10)
+
 
 
 

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -230,5 +230,39 @@ class TestTclObj(unittest.TestCase):
         j /= j
         self.assertEqual(j, 1.0)
 
+    def test_tclobj_math20(self):
+        """exercise tohil.tclobj "floor divide" math ops"""
+        t66 = tohil.tclobj(66)
+        t10 = tohil.tclobj(10)
+        tm7 = tohil.tclobj(-7)
+
+        self.assertEqual(t66 // t10, 66 // 10)
+        self.assertEqual(66 // t10, 66 // 10)
+        self.assertEqual(t66 // 10, 66 // 10)
+
+        self.assertEqual(t66 // tm7, 66 // -7)
+        self.assertEqual(66 // tm7, 66 // -7)
+        self.assertEqual(t66 // -7, 66 // -7)
+
+        self.assertEqual(tm7 // t10, -7 // 10)
+        self.assertEqual(-7 // t10, -7 // 10)
+        self.assertEqual(tm7 // 10, -7 // 10)
+
+    def test_tclobj_math21(self):
+        """exercise tohil.tclobj "inplace floor divide" math ops"""
+        t66 = tohil.tclobj(66)
+        t10 = tohil.tclobj(10)
+        tm7 = tohil.tclobj(-7)
+        r5 = tohil.tclobj(5)
+
+        t = t66
+        t //= 2
+        self.assertEqual(t, 66 // 2)
+        t //= r5
+        self.assertEqual(t, 33 // 5)
+        t = t66
+        t //= tm7
+        self.assertEqual(t, 66 // -7)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -1,0 +1,72 @@
+import unittest
+
+import tohil
+
+
+class TestTclObj(unittest.TestCase):
+    def test_tclobj_math1(self):
+        """exercise tohil.tclobj plus math ops"""
+        t = tohil.tclobj(5)
+
+        self.assertEqual(t + 4, 9)
+        self.assertEqual(t + t, 10)
+        self.assertEqual(6 + t, 11)
+
+        self.assertEqual(t + 4., 9.)
+        self.assertEqual(t + float(t), 10.)
+        self.assertEqual(6. + t, 11.)
+
+    def test_tclobj_math2(self):
+        """exercise tohil.tclobj plus math ops"""
+        t = tohil.tclobj('5')
+
+        self.assertEqual(t - 3, 2)
+        self.assertEqual(t - t, 0)
+        self.assertEqual(6 - t, 1)
+
+        self.assertEqual(t - 4., 1.)
+        self.assertEqual(t - float(t), 0.)
+        self.assertEqual(6. - t, 1.)
+
+    def test_tclobj_math3(self):
+        """exercise tohil.tclobj plus float math ops"""
+        t = tohil.tclobj('5.0')
+
+        self.assertEqual(t - 3, 2.0)
+        self.assertEqual(t - t, 0.0)
+        self.assertEqual(6 - t, 1.0)
+
+        self.assertEqual(t - 4., 1.)
+        self.assertEqual(t - float(t), 0.)
+        self.assertEqual(6. - t, 1.)
+
+    def test_tclobj_math4(self):
+        """exercise tohil.tclobj multiply math ops"""
+        t = tohil.tclobj('6')
+
+        self.assertEqual(t * 3, 18)
+        self.assertEqual(t * t, 36)
+        self.assertEqual(7 * t, 42)
+        self.assertEqual(t * 7, 42)
+
+        self.assertEqual(t * 4., 24.)
+        self.assertEqual(t * float(t), 36.)
+        self.assertEqual(t * t, 36.)
+        self.assertEqual(8. * t, 48.)
+
+    def test_tclobj_math5(self):
+        """exercise tohil.tclobj multiply float math ops"""
+        t = tohil.tclobj('6.')
+
+        self.assertEqual(t * 3, 18.)
+        self.assertEqual(t * t, 36.)
+        self.assertEqual(7 * t, 42.)
+
+        self.assertEqual(t * 4., 24.)
+        self.assertEqual(t * t, 36.)
+        self.assertEqual(-6. * t, -36.)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -210,5 +210,13 @@ class TestTclObj(unittest.TestCase):
         t ^= 17
         self.assertEqual(t, 1)
 
+    def test_tclobj_math18(self):
+        """exercise tohil.tclobj "true divide" math ops"""
+        t = tohil.tclobj(66)
+
+        self.assertEqual(t / 6, 11.0)
+        self.assertEqual(726 / t, 11.0)
+        self.assertEqual(t / t, 1.0)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -218,5 +218,17 @@ class TestTclObj(unittest.TestCase):
         self.assertEqual(726 / t, 11.0)
         self.assertEqual(t / t, 1.0)
 
+    def test_tclobj_math19(self):
+        """exercise tohil.tclobj "inplace true divide" math ops"""
+        t = tohil.tclobj(66)
+
+        t /= 2
+        self.assertEqual(t, 33.0)
+        j = tohil.tclobj(3)
+        t /= j
+        self.assertEqual(t, 11.0)
+        j /= j
+        self.assertEqual(j, 1.0)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -267,5 +267,43 @@ class TestTclObj(unittest.TestCase):
         t //= tm7
         self.assertEqual(t, 66 // -7)
 
+    def test_tclobj_math22(self):
+        """exercise tohil.tclobj inplace remainder ops"""
+        t = tohil.tclobj(5)
+        t %= 7
+        self.assertEqual(t, 5 % 7)
+
+        t = tohil.tclobj(11)
+        t %= 5
+        self.assertEqual(t, 11 % 5)
+
+        t = tohil.tclobj(77)
+        t %= -7
+        self.assertEqual(t, 77 % -7)
+
+        t = tohil.tclobj(-77)
+        t %= -7
+        self.assertEqual(t, -77 % -7)
+
+        t = tohil.tclobj(-77)
+        t %= 7
+        self.assertEqual(t, -77 % 7)
+
+        t = tohil.tclobj(-77)
+        tm7 = tohil.tclobj('-7.')
+        t %= tm7
+        self.assertEqual(t, -77 % -7.)
+
+        t = tohil.tclobj(-77.)
+        tm7 = tohil.tclobj('-7')
+        t %= tm7
+        self.assertEqual(t, -77. % -7)
+
+        t = tohil.tclobj(-77.)
+        tm7 = tohil.tclobj(-7.)
+        t %= tm7
+        self.assertEqual(t, -77. % -7.)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -66,6 +66,19 @@ class TestTclObj(unittest.TestCase):
         self.assertEqual(t * t, 36.)
         self.assertEqual(-6. * t, -36.)
 
+    def test_tclobj_math6(self):
+        """exercise tohil.tclobj remainder math ops"""
+        t = tohil.tclobj(9)
+
+        self.assertEqual(t % 7, 2)
+        self.assertEqual(11 % t, 2)
+        self.assertEqual(-7 % t, 2)
+
+        self.assertEqual(t % -7., -5)
+        self.assertEqual(-7 % 9, 2)
+        self.assertEqual(t % t, 0)
+        self.assertEqual(-6. % t, 3)
+
 
 
 if __name__ == "__main__":

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -112,7 +112,7 @@ class TestTclObj(unittest.TestCase):
         self.assertEqual(t | t, 16)
 
     def test_tclobj_math11(self):
-        """exercise tohil.tclobj "or" math ops"""
+        """exercise tohil.tclobj "xor" math ops"""
         t = tohil.tclobj(31)
 
         self.assertEqual(t ^ 15, 16)
@@ -147,8 +147,68 @@ class TestTclObj(unittest.TestCase):
         t5 -= t
         self.assertEqual(t5, 10)
 
+    def test_tclobj_math14(self):
+        """exercise tohil.tclobj "inplace multiply" math ops"""
+        t = tohil.tclobj(7)
+        t5 = tohil.tclobj(5)
 
+        t *= -1
+        self.assertEqual(t, -7)
+        t *= t
+        self.assertEqual(t, 49)
+        t *= t5
+        self.assertEqual(t, 245)
+        t5 *= t
+        self.assertEqual(t5, 1225)
 
+    def test_tclobj_math15(self):
+        """exercise tohil.tclobj "inplace left shift" math ops"""
+        t = tohil.tclobj(7)
+        t5 = tohil.tclobj(2)
+
+        t <<= 2
+        self.assertEqual(t, 28)
+        t5 <<= t5
+        self.assertEqual(t5, 8)
+
+    def test_tclobj_math16(self):
+        """exercise tohil.tclobj "inplace right shift" math ops"""
+        t = tohil.tclobj(32)
+        t5 = tohil.tclobj(2)
+
+        t >>= 1
+        self.assertEqual(t, 16)
+        t >>= t5
+        self.assertEqual(t, 4)
+
+    def test_tclobj_math16(self):
+        """exercise tohil.tclobj "inplace bitwise or" math ops"""
+        t = tohil.tclobj(16)
+        t2 = tohil.tclobj(8)
+
+        t |= 32
+        self.assertEqual(t, 48)
+        t |= t2
+        self.assertEqual(t, 56)
+
+    def test_tclobj_math17(self):
+        """exercise tohil.tclobj "inplace bitwise and" math ops"""
+        t = tohil.tclobj(31)
+        t2 = tohil.tclobj(8)
+
+        t &= 24
+        self.assertEqual(t, 24)
+        t &= t2
+        self.assertEqual(t, 8)
+
+    def test_tclobj_math17(self):
+        """exercise tohil.tclobj "inplace bitwise xor" math ops"""
+        t = tohil.tclobj(31)
+
+        t ^= 15
+        self.assertEqual(t, 16)
+        t ^= 17
+        self.assertEqual(t, 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -68,16 +68,19 @@ class TestTclObj(unittest.TestCase):
 
     def test_tclobj_math6(self):
         """exercise tohil.tclobj remainder ops"""
-        t = tohil.tclobj(1)
+        t = tohil.tclobj(5)
 
-        self.assertEqual(t % 7, 2)
-        self.assertEqual(11 % t, 2)
-        self.assertEqual(-7 % t, 2)
+        self.assertEqual(t % 7, 5 % 7)
+        self.assertEqual(11 % t, 11 % 5)
+        self.assertEqual(-7 % t, -7 % 5)
+        self.assertEqual(t % -7, 5 % -7)
 
-        self.assertEqual(t % -7., -5)
-        self.assertEqual(-7 % 9, 2)
-        self.assertEqual(t % t, 0)
-        self.assertEqual(-6. % t, 3)
+        tm7 = tohil.tclobj('-7.')
+
+        self.assertEqual(t % -7., 5 % -7.)
+        self.assertEqual(t % tm7, 5 % -7.)
+        self.assertEqual(t % t, 5 % 5)
+        self.assertEqual(tm7 % t, -7 % 5)
 
     def test_tclobj_math7(self):
         """exercise tohil.tclobj left shift math ops"""


### PR DESCRIPTION
This adds "number support" for tohil's tclobj python data type.  As a result, tclobjs having proper contents can be used in numeric calculations for arithmetic, bitwise or, and, and xor, left and right shift, invert, negative, positive, aobsolute value, etc.  In the below, t or val or both can be tclobjs.
* `t + val`
* `t - val`
* `t * val`
* `t % val`
 * `t / val`
* `t // val`
* `t | val`
* `t &= val`
* `t <<= val`
* `t >>= val`
* `t ^= val`



Also in-place methods are support, so tohil tclobjs can be the source or destination of expressions such as `a += b`, etc.  `+=` can also be used for concatenation when number addition fails due to the contents of the values.  In the below, t is always a tclobj, and val can be a tclobj as well as a python int in all cases and a python float in certain ones (you can't left shift by a floating point amount, for instance.)
* `t += val`
* `t -= val`
* `t *= val`
* `t %= val`
* `t |= val`
* `t &= val`
* `t <<= val`
* `t >>= val`
* `t ^= val`

* Python-standard true divide and floor divide and in-place true divide and floor divide are provided.
* tclobj now has type-based support for int(), float(), bool(), (it already had str()), so we have removed the tclobj methods as_int(), as_float(), as_bool(), and as_str(), as they can now be accessed at least as efficiently and in a more standard way using int(), float(), bool() and str().
* For bool this is cool because the default behavior was incorrect.  an empty tclobj would return false but anything else would return true.  Now you get tcl semantics, 'f', 'F', 'n', 'N', 0 are false, 't', 'T', 'y', 'Y', any number other than zero evaluate true; any other garbage is an error.
* For the curious, tclobj._pyrefcount returns the python reference count (tclobj._refcount returns the tcl object reference count)
* Many new tests
* Version bump to 3.2.0