### PR TITLE
Tclobj var

### DIFF
--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -871,21 +871,33 @@ TohilTclObj_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         self->tclobj = NULL;
 
         Tcl_Obj *newObj;
-        if (pFrom == NULL) {
-            if (STREQU(type->tp_name, "tohil.tcldict")) {
-                newObj = Tcl_NewDictObj();
-            } else {
-                newObj = Tcl_NewObj();
-            }
-        } else {
-            newObj = pyObjToTcl(self->interp, pFrom);
-        }
+        // it's from or empty if it gets to here but
+        // if they specified a var= then we don't
+        // want to clobber it
 
+        // if there's a var, connect to that
         if (tVar != NULL) {
             self->tclvar = Tcl_NewStringObj(tVar, -1);
             Tcl_IncrRefCount(self->tclvar);
-            TohilTclObj_stuff_var(self, newObj);
+
+            // if they specified a from, plug it into the var
+            if (pFrom != NULL) {
+                newObj = pyObjToTcl(self->interp, pFrom);
+                TohilTclObj_stuff_var(self, newObj);
+            }
         } else {
+            // there isn't a var, fill the tclobj
+            // if there's no source, make a new tclobj
+            if (pFrom == NULL) {
+                if (STREQU(type->tp_name, "tohil.tcldict")) {
+                    newObj = Tcl_NewDictObj();
+                } else {
+                    newObj = Tcl_NewObj();
+                }
+            } else {
+                // there's a source=, use that for the new tclobj
+                newObj = pyObjToTcl(self->interp, pFrom);
+            }
             self->tclobj = newObj;
             Tcl_IncrRefCount(self->tclobj);
         }

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1708,9 +1708,14 @@ TohilTclObj_ass_item(TohilTclObj *self, Py_ssize_t i, PyObject *v)
         return -1;
     }
 
-    Tcl_Obj *writeObj = TohilTclObj_writable_objptr(self);
+    Tcl_Obj *writeObj = TohilTclObj_objptr(self);
     if (writeObj == NULL)
         return -1;
+
+    if (Tcl_IsShared(writeObj)) {
+        Tcl_DecrRefCount(writeObj);
+        writeObj = Tcl_DuplicateObj(writeObj);
+    }
 
     if (Tcl_ListObjReplace(self->interp, writeObj, i, 1, 1, &obj) == TCL_ERROR) {
         PyErr_SetString(PyExc_IndexError, Tcl_GetString(Tcl_GetObjResult(self->interp)));


### PR DESCRIPTION
tclobjs can now shadow a tcl variable or array element such that if created with the var=varname argument, every access of tclobj's underlying tcl object will be made from the tcl variable, and every store to it will be stored into the tcl variable.