### PR TITLE
Raise division-by-zero exceptions instead of causing SIGFPEs on divide by zero; Hypothesis

### DIFF
--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2615,6 +2615,7 @@ tclobj_nb_inplace_true_divide(PyObject *v, PyObject *w)
 static PyNumberMethods tclobj_as_number = {
     .nb_bool = (inquiry)tclobj_nb_bool,
     .nb_int = tclobj_nb_long,
+    .nb_index = tclobj_nb_long,
     .nb_float = tclobj_nb_float,
     .nb_add = tclobj_nb_add,
     .nb_subtract = tclobj_nb_subtract,

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2209,15 +2209,31 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             return PyFloat_FromDouble(doubleV * doubleW);
 
         case Truediv:
+            if (doubleW == 0.0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                return NULL;
+            }
             return PyFloat_FromDouble(doubleV / doubleW);
 
         case Floordiv:
+            if (doubleW == 0.0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                return NULL;
+            }
             return PyFloat_FromDouble(floor(doubleV / doubleW));
 
         case Remainder:
+            if (doubleW == 0.0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                return NULL;
+            }
             return PyFloat_FromDouble(fmod(fmod(doubleV, doubleW) + doubleW, doubleW));
 
         case Divmod:
+            if (doubleW == 0.0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                return NULL;
+            }
             quotient = doubleV / doubleW;
             remainder = fmod(doubleV, doubleW);
             return Py_BuildValue("dd", quotient, remainder);
@@ -2252,9 +2268,17 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             return PyLong_FromLong(longV >> longW);
 
         case Truediv:
+            if (longW == 0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+                return NULL;
+            }
             return PyFloat_FromDouble((double)longV / (double)longW);
 
         case Floordiv:
+            if (longW == 0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+                return NULL;
+            }
             ldiv_res = ldiv(longV, longW);
             if (ldiv_res.rem != 0 && ((longV < 0) ^ (longW < 0))) {
                 ldiv_res.quot--;
@@ -2262,9 +2286,17 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             return PyLong_FromLong(ldiv_res.quot);
 
         case Remainder:
+            if (longW == 0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+                return NULL;
+            }
             return PyLong_FromLong(((longV % longW) + longW) % longW);
 
         case Divmod:
+            if (longW == 0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+                return NULL;
+            }
             ldiv_res = ldiv(longV, longW);
             return Py_BuildValue("ll", ldiv_res.quot, ldiv_res.rem);
 
@@ -2420,14 +2452,26 @@ tclobj_inplace_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             break;
 
         case Remainder:
+            if (doubleW == 0.0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                return NULL;
+            }
             Tcl_SetDoubleObj(writeObj, fmod(fmod(doubleV, doubleW) + doubleW, doubleW));
             break;
 
         case Truediv:
+            if (doubleW == 0.0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                return NULL;
+            }
             Tcl_SetDoubleObj(writeObj, doubleV / doubleW);
             break;
 
         case Floordiv:
+            if (doubleW == 0.0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                return NULL;
+            }
             Tcl_SetDoubleObj(writeObj, floor(doubleV / doubleW));
             break;
 
@@ -2469,10 +2513,18 @@ tclobj_inplace_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             break;
 
         case Truediv:
+            if (longW == 0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+                return NULL;
+            }
             Tcl_SetDoubleObj(writeObj, (double)longV / (double)longW);
             break;
 
         case Floordiv:
+            if (longW == 0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+                return NULL;
+            }
             ldiv_res = ldiv(longV, longW);
             if (ldiv_res.rem != 0 && ((longV < 0) ^ (longW < 0))) {
                 ldiv_res.quot--;
@@ -2481,6 +2533,10 @@ tclobj_inplace_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             break;
 
         case Remainder:
+            if (longW == 0) {
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
+                return NULL;
+            }
             Tcl_SetLongObj(writeObj, ((longV % longW) + longW) % longW);
             break;
 

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2033,7 +2033,7 @@ static PyTypeObject PyTohil_TD_IterType = {
 //
 
 static int
-tclobj_bool(TohilTclObj *self)
+tclobj_nb_bool(TohilTclObj *self)
 {
     int intValue = 0;
 
@@ -2049,7 +2049,7 @@ tclobj_bool(TohilTclObj *self)
 }
 
 static PyObject *
-tclobj_long(PyObject *p)
+tclobj_nb_long(PyObject *p)
 {
     long longValue = 0;
 
@@ -2070,7 +2070,7 @@ tclobj_long(PyObject *p)
 }
 
 static PyObject *
-tclobj_float(PyObject *p)
+tclobj_nb_float(PyObject *p)
 {
     double doubleValue = 0;
     TohilTclObj *self = (TohilTclObj *)p;
@@ -2120,7 +2120,7 @@ tohil_pyobj_to_number(PyObject *v, long *longPtr, double *doublePtr)
 enum tclobj_unary_op { Abs, Negative, Positive, Invert };
 
 static PyObject *
-tclobj_unaryop(PyObject *v, enum tclobj_unary_op operator)
+tclobj_nb_unaryop(PyObject *v, enum tclobj_unary_op operator)
 {
     double doubleV = 0.0;
     long longV = 0;
@@ -2167,7 +2167,7 @@ tclobj_unaryop(PyObject *v, enum tclobj_unary_op operator)
 enum tclobj_op { Add, Sub, Mul, And, Or, Xor, Lshift, Rshift, Remainder, Divmod, Truediv, Floordiv };
 
 static PyObject *
-tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
+tclobj_nb_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
 {
     double doubleV = 0.0;
     long longV = 0;
@@ -2307,103 +2307,103 @@ tclobj_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
 }
 
 static PyObject *
-tclobj_add(PyObject *v, PyObject *w)
+tclobj_nb_add(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Add);
+    return tclobj_nb_binop(v, w, Add);
 }
 
 static PyObject *
-tclobj_subtract(PyObject *v, PyObject *w)
+tclobj_nb_subtract(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Sub);
+    return tclobj_nb_binop(v, w, Sub);
 }
 
 static PyObject *
-tclobj_multiply(PyObject *v, PyObject *w)
+tclobj_nb_multiply(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Mul);
+    return tclobj_nb_binop(v, w, Mul);
 }
 
 static PyObject *
-tclobj_true_divide(PyObject *v, PyObject *w)
+tclobj_nb_true_divide(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Truediv);
+    return tclobj_nb_binop(v, w, Truediv);
 }
 
 static PyObject *
-tclobj_floor_divide(PyObject *v, PyObject *w)
+tclobj_nb_floor_divide(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Floordiv);
+    return tclobj_nb_binop(v, w, Floordiv);
 }
 
 static PyObject *
-tclobj_remainder(PyObject *v, PyObject *w)
+tclobj_nb_remainder(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Remainder);
+    return tclobj_nb_binop(v, w, Remainder);
 }
 
 static PyObject *
-tclobj_divmod(PyObject *v, PyObject *w)
+tclobj_nb_divmod(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Divmod);
+    return tclobj_nb_binop(v, w, Divmod);
 }
 
 static PyObject *
-tclobj_and(PyObject *v, PyObject *w)
+tclobj_nb_and(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, And);
+    return tclobj_nb_binop(v, w, And);
 }
 
 static PyObject *
-tclobj_or(PyObject *v, PyObject *w)
+tclobj_nb_or(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Or);
+    return tclobj_nb_binop(v, w, Or);
 }
 
 static PyObject *
-tclobj_xor(PyObject *v, PyObject *w)
+tclobj_nb_xor(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Xor);
+    return tclobj_nb_binop(v, w, Xor);
 }
 
 static PyObject *
-tclobj_lshift(PyObject *v, PyObject *w)
+tclobj_nb_lshift(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Lshift);
+    return tclobj_nb_binop(v, w, Lshift);
 }
 
 static PyObject *
-tclobj_rshift(PyObject *v, PyObject *w)
+tclobj_nb_rshift(PyObject *v, PyObject *w)
 {
-    return tclobj_binop(v, w, Rshift);
+    return tclobj_nb_binop(v, w, Rshift);
 }
 
 static PyObject *
-tclobj_negative(PyObject *v, enum tclobj_op operator)
+tclobj_nb_negative(PyObject *v, enum tclobj_op operator)
 {
-    return tclobj_unaryop(v, Negative);
+    return tclobj_nb_unaryop(v, Negative);
 }
 
 static PyObject *
-tclobj_positive(PyObject *v, enum tclobj_op operator)
+tclobj_nb_positive(PyObject *v, enum tclobj_op operator)
 {
-    return tclobj_unaryop(v, Positive);
+    return tclobj_nb_unaryop(v, Positive);
 }
 
 static PyObject *
-tclobj_absolute(PyObject *v, enum tclobj_op operator)
+tclobj_nb_absolute(PyObject *v, enum tclobj_op operator)
 {
-    return tclobj_unaryop(v, Abs);
+    return tclobj_nb_unaryop(v, Abs);
 }
 
 static PyObject *
-tclobj_invert(PyObject *v, enum tclobj_op operator)
+tclobj_nb_invert(PyObject *v, enum tclobj_op operator)
 {
-    return tclobj_unaryop(v, Invert);
+    return tclobj_nb_unaryop(v, Invert);
 }
 
 static PyObject *
-tclobj_inplace_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
+tclobj_nb_inplace_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
 {
     // NB same chunk of code in tclobj_binop
     double doubleV = 0.0;
@@ -2553,96 +2553,96 @@ tclobj_inplace_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
 }
 
 static PyObject *
-tclobj_inplace_add(PyObject *v, PyObject *w)
+tclobj_nb_inplace_add(PyObject *v, PyObject *w)
 {
-    return tclobj_inplace_binop(v, w, Add);
+    return tclobj_nb_inplace_binop(v, w, Add);
 }
 
 static PyObject *
-tclobj_inplace_subtract(PyObject *v, PyObject *w)
+tclobj_nb_inplace_subtract(PyObject *v, PyObject *w)
 {
-    return tclobj_inplace_binop(v, w, Sub);
+    return tclobj_nb_inplace_binop(v, w, Sub);
 }
 
 static PyObject *
-tclobj_inplace_multiply(PyObject *v, PyObject *w)
+tclobj_nb_inplace_multiply(PyObject *v, PyObject *w)
 {
-    return tclobj_inplace_binop(v, w, Mul);
+    return tclobj_nb_inplace_binop(v, w, Mul);
 }
 
 static PyObject *
-tclobj_inplace_remainder(PyObject *v, PyObject *w)
+tclobj_nb_inplace_remainder(PyObject *v, PyObject *w)
 {
-    return tclobj_inplace_binop(v, w, Remainder);
+    return tclobj_nb_inplace_binop(v, w, Remainder);
 }
 
 static PyObject *
-tclobj_inplace_and(PyObject *v, PyObject *w)
+tclobj_nb_inplace_and(PyObject *v, PyObject *w)
 {
-    return tclobj_inplace_binop(v, w, And);
+    return tclobj_nb_inplace_binop(v, w, And);
 }
 
 static PyObject *
-tclobj_inplace_or(PyObject *v, PyObject *w)
+tclobj_nb_inplace_or(PyObject *v, PyObject *w)
 {
-    return tclobj_inplace_binop(v, w, Or);
+    return tclobj_nb_inplace_binop(v, w, Or);
 }
 
 static PyObject *
-tclobj_inplace_xor(PyObject *v, PyObject *w)
+tclobj_nb_inplace_xor(PyObject *v, PyObject *w)
 {
-    return tclobj_inplace_binop(v, w, Xor);
+    return tclobj_nb_inplace_binop(v, w, Xor);
 }
 
 static PyObject *
-tclobj_inplace_lshift(PyObject *v, PyObject *w)
+tclobj_nb_inplace_lshift(PyObject *v, PyObject *w)
 {
-    return tclobj_inplace_binop(v, w, Lshift);
+    return tclobj_nb_inplace_binop(v, w, Lshift);
 }
 
 static PyObject *
-tclobj_inplace_rshift(PyObject *v, PyObject *w)
+tclobj_nb_inplace_rshift(PyObject *v, PyObject *w)
 {
-    return tclobj_inplace_binop(v, w, Rshift);
+    return tclobj_nb_inplace_binop(v, w, Rshift);
 }
 
 static PyObject *
-tclobj_inplace_true_divide(PyObject *v, PyObject *w)
+tclobj_nb_inplace_true_divide(PyObject *v, PyObject *w)
 {
-    return tclobj_inplace_binop(v, w, Truediv);
+    return tclobj_nb_inplace_binop(v, w, Truediv);
 }
 
 static PyNumberMethods tclobj_as_number = {
-    .nb_bool = (inquiry)tclobj_bool,
-    .nb_int = tclobj_long,
-    .nb_float = tclobj_float,
-    .nb_add = tclobj_add,
-    .nb_subtract = tclobj_subtract,
-    .nb_multiply = tclobj_multiply,
-    .nb_true_divide = tclobj_true_divide,
-    .nb_floor_divide = tclobj_floor_divide,
-    .nb_remainder = tclobj_remainder,
-    .nb_divmod = tclobj_divmod,
-    .nb_and = tclobj_and,
-    .nb_or = tclobj_or,
-    .nb_xor = tclobj_xor,
-    .nb_lshift = tclobj_lshift,
-    .nb_rshift = tclobj_rshift,
-    .nb_negative = (unaryfunc)tclobj_negative,
-    .nb_positive = (unaryfunc)tclobj_positive,
-    .nb_absolute = (unaryfunc)tclobj_absolute,
-    .nb_invert = (unaryfunc)tclobj_invert,
+    .nb_bool = (inquiry)tclobj_nb_bool,
+    .nb_int = tclobj_nb_long,
+    .nb_float = tclobj_nb_float,
+    .nb_add = tclobj_nb_add,
+    .nb_subtract = tclobj_nb_subtract,
+    .nb_multiply = tclobj_nb_multiply,
+    .nb_true_divide = tclobj_nb_true_divide,
+    .nb_floor_divide = tclobj_nb_floor_divide,
+    .nb_remainder = tclobj_nb_remainder,
+    .nb_divmod = tclobj_nb_divmod,
+    .nb_and = tclobj_nb_and,
+    .nb_or = tclobj_nb_or,
+    .nb_xor = tclobj_nb_xor,
+    .nb_lshift = tclobj_nb_lshift,
+    .nb_rshift = tclobj_nb_rshift,
+    .nb_negative = (unaryfunc)tclobj_nb_negative,
+    .nb_positive = (unaryfunc)tclobj_nb_positive,
+    .nb_absolute = (unaryfunc)tclobj_nb_absolute,
+    .nb_invert = (unaryfunc)tclobj_nb_invert,
 
-    .nb_inplace_add = tclobj_inplace_add,
-    .nb_inplace_subtract = tclobj_inplace_subtract,
-    .nb_inplace_multiply = tclobj_inplace_multiply,
-    .nb_inplace_remainder = tclobj_inplace_remainder,
-    .nb_inplace_lshift = tclobj_inplace_lshift,
-    .nb_inplace_rshift = tclobj_inplace_rshift,
-    .nb_inplace_and = tclobj_inplace_and,
-    .nb_inplace_or = tclobj_inplace_or,
-    .nb_inplace_xor = tclobj_inplace_xor,
-    .nb_inplace_true_divide = tclobj_inplace_true_divide,
+    .nb_inplace_add = tclobj_nb_inplace_add,
+    .nb_inplace_subtract = tclobj_nb_inplace_subtract,
+    .nb_inplace_multiply = tclobj_nb_inplace_multiply,
+    .nb_inplace_remainder = tclobj_nb_inplace_remainder,
+    .nb_inplace_lshift = tclobj_nb_inplace_lshift,
+    .nb_inplace_rshift = tclobj_nb_inplace_rshift,
+    .nb_inplace_and = tclobj_nb_inplace_and,
+    .nb_inplace_or = tclobj_nb_inplace_or,
+    .nb_inplace_xor = tclobj_nb_inplace_xor,
+    .nb_inplace_true_divide = tclobj_nb_inplace_true_divide,
 };
 
 //

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,60 +1,65 @@
+
+import hypothesis
+from hypothesis import given, assume, strategies as st
 import unittest
 
 import tohil
 
 
 class TestMethods(unittest.TestCase):
-    def test_convert1(self):
+    @given(st.integers(-2000000, 2000000))
+    def test_convert1(self, i):
         """exercise tohil.convert with no to= and with to=str"""
-        self.assertEqual(tohil.convert(10), "10")
-        self.assertEqual(tohil.convert(10, to=str), "10")
-        self.assertEqual(tohil.convert("10"), "10")
-        self.assertEqual(tohil.convert("10", to=str), "10")
+        assert(tohil.convert(i) == str(i))
+        assert(tohil.convert(i, to=str) == str(i))
+        assert(tohil.convert(str(i)) == str(i))
 
-    def test_convert2(self):
+    @given(st.integers(-2000000, 2000000))
+    def test_convert2(self, i):
         """exercise tohil.convert and to=int and to=float"""
-        self.assertEqual(tohil.convert("10", to=int), 10)
-        self.assertEqual(tohil.convert("10", to=float), 10.0)
+        assert(tohil.convert(i, to=int) == i)
+        assert(tohil.convert(i, to=float) == float(i))
 
     def test_convert3(self):
         """exercise tohil.convert to=bool"""
-        self.assertEqual(tohil.convert(True, to=bool), True)
-        self.assertEqual(tohil.convert("t", to=bool), True)
-        self.assertEqual(tohil.convert("1", to=bool), True)
-        self.assertEqual(tohil.convert(1, to=bool), True)
-        self.assertEqual(tohil.convert(False, to=bool), False)
-        self.assertEqual(tohil.convert("f", to=bool), False)
-        self.assertEqual(tohil.convert("0", to=bool), False)
-        self.assertEqual(tohil.convert(0, to=bool), False)
+        assert(tohil.convert(True, to=bool) == True)
+        assert(tohil.convert("t", to=bool) == True)
+        assert(tohil.convert("1", to=bool) == True)
+        assert(tohil.convert(1, to=bool) == True)
+        assert(tohil.convert(False, to=bool) == False)
+        assert(tohil.convert("f", to=bool) == False)
+        assert(tohil.convert("0", to=bool) == False)
+        assert(tohil.convert(0, to=bool) == False)
 
-    def test_convert4(self):
+    @given(st.lists(st.integers(-1000000000, 1000000000)))
+    def test_convert4(self, ilist):
         """exercise tohil.convert to=list"""
-        self.assertEqual(tohil.convert("1 2 3 4 5", to=list), ["1", "2", "3", "4", "5"])
+        assert(tohil.convert(ilist, to=list) == ilist)
 
     def test_convert5(self):
         """exercise tohil.convert and to=dict"""
-        self.assertEqual(
+        assert(
             tohil.convert("a 1 b 2 c 3 d 4", to=dict),
             {"a": "1", "b": "2", "c": "3", "d": "4"},
         )
 
     def test_convert6(self):
         """exercise tohil.convert and to=tuple"""
-        self.assertEqual(
+        assert(
             tohil.convert("a 1 b 2 c 3 d 4", to=tuple),
             ("a", "1", "b", "2", "c", "3", "d", "4"),
         )
 
     def test_convert7(self):
         """exercise tohil.convert and to=set"""
-        self.assertEqual(
+        assert(
             sorted(tohil.convert("1 2 3 4 5 6 6", to=set)),
             ["1", "2", "3", "4", "5", "6"],
         )
 
     def test_convert8(self):
         """exercise tohil.convert and to=tohil.tclobj"""
-        self.assertEqual(
+        assert(
             repr(tohil.convert("1 2 3", to=tohil.tclobj)), "<tohil.tclobj: '1 2 3'>"
         )
 

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -1,168 +1,201 @@
+
+import hypothesis
+from hypothesis import given, assume, strategies as st
 import unittest
 
 import tohil
 
-
 class TestTclObj(unittest.TestCase):
-    def test_tclobj_math1(self):
-        """exercise tohil.tclobj plus math ops"""
-        t = tohil.tclobj(5)
+    @given(st.integers(-40000, 40000), st.integers(-40000, 40000))
+    def test_tclobj_math1(self, i, j):
+        """exercise tohil.tclobj 'plus' math ops"""
+        t = tohil.tclobj(i)
 
-        self.assertEqual(t + 4, 9)
-        self.assertEqual(t + t, 10)
-        self.assertEqual(6 + t, 11)
+        assert(t + j == i + j)
+        assert(t + t == i + i)
+        assert(6 + t == 6 + i)
 
-        self.assertEqual(t + 4., 9.)
-        self.assertEqual(t + float(t), 10.)
-        self.assertEqual(6. + t, 11.)
+        assert(t + 4. == i + 4.)
+        assert(4. + t == i + 4.)
+        assert(t + float(t) == i + float(i))
+        assert(6. + t == 6. + i)
 
-    def test_tclobj_math2(self):
-        """exercise tohil.tclobj plus math ops"""
-        t = tohil.tclobj('5')
+    @given(st.integers(-40000, 40000), st.integers(-40000, 40000))
+    def test_tclobj_math2(self, i, j):
+        """exercise tohil.tclobj 'minus' math ops"""
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        self.assertEqual(t - 3, 2)
-        self.assertEqual(t - t, 0)
-        self.assertEqual(6 - t, 1)
+        assert(ti - 3 == i - 3)
+        assert(ti - ti == 0)
+        assert(6 - ti == 6 - i)
 
-        self.assertEqual(t - 4., 1.)
-        self.assertEqual(t - float(t), 0.)
-        self.assertEqual(6. - t, 1.)
+        assert(tj - 4. == j - 4.)
+        assert(tj - float(tj) == 0.)
+        assert(6. - ti == 6 - i)
 
-    def test_tclobj_math3(self):
+        assert(tj - ti == j - i)
+
+    @given(st.floats(-40000.0, 40000.0), st.integers(-40000, 40000))
+    def test_tclobj_math3(self, f, i):
         """exercise tohil.tclobj plus float math ops"""
-        t = tohil.tclobj('5.0')
+        t = tohil.tclobj(f)
 
-        self.assertEqual(t - 3, 2.0)
-        self.assertEqual(t - t, 0.0)
-        self.assertEqual(6 - t, 1.0)
+        assert(t == f)
+        assert(t - i == f - i)
+        assert(t - t == 0.0)
+        assert(6 - t == 6 - f)
 
-        self.assertEqual(t - 4., 1.)
-        self.assertEqual(t - float(t), 0.)
-        self.assertEqual(6. - t, 1.)
+        assert(i - t == i - f)
+        assert(int(t) - i == int(t) - i)
+        assert(6. - t == 6. - f)
 
-    def test_tclobj_math4(self):
+    @given(st.integers(-40000.0, 40000.0), st.integers(-40000, 40000))
+    def test_tclobj_math4(self, i, j):
         """exercise tohil.tclobj multiply math ops"""
-        t = tohil.tclobj('6')
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        self.assertEqual(t * 3, 18)
-        self.assertEqual(t * t, 36)
-        self.assertEqual(7 * t, 42)
-        self.assertEqual(t * 7, 42)
+        assert(ti * 3 == i * 3)
+        assert(ti * j == i * j)
+        assert(j * ti == i * j)
+        assert(tj * ti == i * j)
+        assert(7 * ti == 7 * i)
+        assert(ti * 7 == 7 * i)
+        assert(ti * ti == i * i)
 
-        self.assertEqual(t * 4., 24.)
-        self.assertEqual(t * float(t), 36.)
-        self.assertEqual(t * t, 36.)
-        self.assertEqual(8. * t, 48.)
+        assert(ti * 4. == i * 4.)
+        assert(ti * float(ti) == i * float(i))
+        assert(8. * ti == 8. * i)
 
-    def test_tclobj_math5(self):
+    @given(st.floats(-40000.0, 40000.0), st.floats(-40000, 40000))
+    def test_tclobj_math5(self, u, v):
         """exercise tohil.tclobj multiply float math ops"""
-        t = tohil.tclobj('6.')
+        t6 = tohil.tclobj('6.')
+        tu = tohil.tclobj(u)
+        tv = tohil.tclobj(v)
 
-        self.assertEqual(t * 3, 18.)
-        self.assertEqual(t * t, 36.)
-        self.assertEqual(7 * t, 42.)
+        assert(tu * 6 == u * 6)
+        assert(tu * 6. == u * 6.)
+        assert(tu * t6== u * 6.)
+        assert(tu * tu == u * u)
 
-        self.assertEqual(t * 4., 24.)
-        self.assertEqual(t * t, 36.)
-        self.assertEqual(-6. * t, -36.)
+        assert(tu * tv == u * v)
 
-    def test_tclobj_math6(self):
+    @given(st.integers(-40000, 40000), st.integers(-40000, 40000))
+    def test_tclobj_math6(self, i, j):
         """exercise tohil.tclobj remainder ops"""
-        t = tohil.tclobj(5)
+        assume(i != 0 and j != 0)
 
-        self.assertEqual(t % 7, 5 % 7)
-        self.assertEqual(11 % t, 11 % 5)
-        self.assertEqual(-7 % t, -7 % 5)
-        self.assertEqual(t % -7, 5 % -7)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        tm7 = tohil.tclobj('-7.')
+        assert(ti % 7 == i % 7)
+        assert(ti % j == i % j)
+        assert(11 % ti == 11 % i)
+        assert(-7 % ti == -7 % i)
+        assert(ti % -7 == i % -7)
 
-        self.assertEqual(t % -7., 5 % -7.)
-        self.assertEqual(t % tm7, 5 % -7.)
-        self.assertEqual(t % t, 5 % 5)
-        self.assertEqual(tm7 % t, -7 % 5)
+        assert(ti % tj == i % j)
+        assert(ti % j == i % j)
+        assert(i % tj == i % j)
 
-    def test_tclobj_math7(self):
+    @given(st.integers(0, 1024), st.integers(0, 23))
+    def test_tclobj_math7(self, i, j):
         """exercise tohil.tclobj left shift math ops"""
-        t = tohil.tclobj(2)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        self.assertEqual(t << 4, 32)
-        self.assertEqual(t << t, 8)
-        self.assertEqual(16 << 2, 64)
+        assert(ti << j == i << j)
+        assert(ti << tj == i << j)
+        assert(i << tj == i << j)
 
-    def test_tclobj_math8(self):
+        assert(ti << 4 == i << 4)
+        assert(4 << tj == 4 << j)
+
+    @given(st.integers(0, 2000000000), st.integers(0, 23))
+    def test_tclobj_math8(self, i, j):
         """exercise tohil.tclobj right shift math ops"""
-        t = tohil.tclobj(8)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        self.assertEqual(t >> 1, 4)
-        self.assertEqual(t >> t, 0)
-        self.assertEqual(65536 >> t, 256)
+        assert(ti >> j == i >> j)
+        assert(ti >> tj == i >> j)
+        assert(i >> tj == i >> j)
 
-    def test_tclobj_math9(self):
+    @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
+    def test_tclobj_math9(self, i, j):
         """exercise tohil.tclobj "and" math ops"""
-        t = tohil.tclobj(31)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        self.assertEqual(t & 16, 16)
-        self.assertEqual(t & t, 31)
-        self.assertEqual(8 & t, 8)
+        assert(ti & j == i & j)
+        assert(ti & tj == i & j)
+        assert(i & tj == i & j)
 
-    def test_tclobj_math10(self):
+    @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
+    def test_tclobj_math10(self, i j):
         """exercise tohil.tclobj "or" math ops"""
-        t = tohil.tclobj(16)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        self.assertEqual(t | 8, 24)
-        self.assertEqual(4 | t, 20)
-        self.assertEqual(t | t, 16)
+        assert(ti | j, i | j)
+        assert(ti | tj, i | j)
+        assert(i | tj, i | j)
 
-    def test_tclobj_math11(self):
+    @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
+    def test_tclobj_math11(self, i j):
         """exercise tohil.tclobj "xor" math ops"""
-        t = tohil.tclobj(31)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        self.assertEqual(t ^ 15, 16)
-        self.assertEqual(15 ^ t, 16)
-        self.assertEqual(t ^ t, 0)
+        assert(ti ^ j == i ^ j)
+        assert(ti ^ tj == i ^ j)
+        assert(i ^ tj == i ^ j)
 
-    def test_tclobj_math12(self):
+    @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
+    def test_tclobj_math12(self, i, j):
         """exercise tohil.tclobj "inplace add" math ops"""
-        t = tohil.tclobj(7)
-        t5 = tohil.tclobj(5)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        t += 5
-        self.assertEqual(t, 12)
-        t += t
-        self.assertEqual(t, 24)
-        t += t5
-        self.assertEqual(t, 29)
-        t5 += t
-        self.assertEqual(t5, 34)
+        ti += j
+        assert(ti == i + j)
 
+        ti = tohil.tclobj(i)
+        ti += ti
+        assert(ti == i + i)
+
+        ti = tohil.tclobj(i)
+        ti += tj
+        assert(ti == i + j)
+
+    @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
     def test_tclobj_math13(self):
         """exercise tohil.tclobj "inplace subtract" math ops"""
-        t = tohil.tclobj(7)
-        t5 = tohil.tclobj(5)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        t -= -1
-        self.assertEqual(t, 8)
-        t -= t
-        self.assertEqual(t, 0)
-        t -= t5
-        self.assertEqual(t, -5)
-        t5 -= t
-        self.assertEqual(t5, 10)
+        ti -= j
+        assert(ti == i - j)
 
-    def test_tclobj_math14(self):
+        ti = tohil.tclobj(i)
+        ti -= tj
+        assert(ti == i - j)
+
+    @given(st.integers(-40000, 40000), st.integers(-40000, 40000))
+    def test_tclobj_math14(self, i j):
         """exercise tohil.tclobj "inplace multiply" math ops"""
-        t = tohil.tclobj(7)
-        t5 = tohil.tclobj(5)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        t *= -1
-        self.assertEqual(t, -7)
-        t *= t
-        self.assertEqual(t, 49)
-        t *= t5
-        self.assertEqual(t, 245)
-        t5 *= t
-        self.assertEqual(t5, 1225)
+        ti *= j
+        assert(ti == i * j)
+
+        ti = tohil.tclobj(i)
+        ti *= tj
+        assert(ti == i * j)
+
 
     def test_tclobj_math15(self):
         """exercise tohil.tclobj "inplace left shift" math ops"""
@@ -170,9 +203,9 @@ class TestTclObj(unittest.TestCase):
         t5 = tohil.tclobj(2)
 
         t <<= 2
-        self.assertEqual(t, 28)
+        assert(t, 28)
         t5 <<= t5
-        self.assertEqual(t5, 8)
+        assert(t5, 8)
 
     def test_tclobj_math16(self):
         """exercise tohil.tclobj "inplace right shift" math ops"""
@@ -180,9 +213,9 @@ class TestTclObj(unittest.TestCase):
         t5 = tohil.tclobj(2)
 
         t >>= 1
-        self.assertEqual(t, 16)
+        assert(t, 16)
         t >>= t5
-        self.assertEqual(t, 4)
+        assert(t, 4)
 
     def test_tclobj_math16(self):
         """exercise tohil.tclobj "inplace bitwise or" math ops"""
@@ -190,9 +223,9 @@ class TestTclObj(unittest.TestCase):
         t2 = tohil.tclobj(8)
 
         t |= 32
-        self.assertEqual(t, 48)
+        assert(t, 48)
         t |= t2
-        self.assertEqual(t, 56)
+        assert(t, 56)
 
     def test_tclobj_math17(self):
         """exercise tohil.tclobj "inplace bitwise and" math ops"""
@@ -200,38 +233,38 @@ class TestTclObj(unittest.TestCase):
         t2 = tohil.tclobj(8)
 
         t &= 24
-        self.assertEqual(t, 24)
+        assert(t, 24)
         t &= t2
-        self.assertEqual(t, 8)
+        assert(t, 8)
 
     def test_tclobj_math17(self):
         """exercise tohil.tclobj "inplace bitwise xor" math ops"""
         t = tohil.tclobj(31)
 
         t ^= 15
-        self.assertEqual(t, 16)
+        assert(t, 16)
         t ^= 17
-        self.assertEqual(t, 1)
+        assert(t, 1)
 
     def test_tclobj_math18(self):
         """exercise tohil.tclobj "true divide" math ops"""
         t = tohil.tclobj(66)
 
-        self.assertEqual(t / 6, 11.0)
-        self.assertEqual(726 / t, 11.0)
-        self.assertEqual(t / t, 1.0)
+        assert(t / 6, 11.0)
+        assert(726 / t, 11.0)
+        assert(t / t, 1.0)
 
     def test_tclobj_math19(self):
         """exercise tohil.tclobj "inplace true divide" math ops"""
         t = tohil.tclobj(66)
 
         t /= 2
-        self.assertEqual(t, 33.0)
+        assert(t, 33.0)
         j = tohil.tclobj(3)
         t /= j
-        self.assertEqual(t, 11.0)
+        assert(t, 11.0)
         j /= j
-        self.assertEqual(j, 1.0)
+        assert(j, 1.0)
 
     def test_tclobj_math20(self):
         """exercise tohil.tclobj "floor divide" math ops"""
@@ -239,17 +272,17 @@ class TestTclObj(unittest.TestCase):
         t10 = tohil.tclobj(10)
         tm7 = tohil.tclobj(-7)
 
-        self.assertEqual(t66 // t10, 66 // 10)
-        self.assertEqual(66 // t10, 66 // 10)
-        self.assertEqual(t66 // 10, 66 // 10)
+        assert(t66 // t10, 66 // 10)
+        assert(66 // t10, 66 // 10)
+        assert(t66 // 10, 66 // 10)
 
-        self.assertEqual(t66 // tm7, 66 // -7)
-        self.assertEqual(66 // tm7, 66 // -7)
-        self.assertEqual(t66 // -7, 66 // -7)
+        assert(t66 // tm7, 66 // -7)
+        assert(66 // tm7, 66 // -7)
+        assert(t66 // -7, 66 // -7)
 
-        self.assertEqual(tm7 // t10, -7 // 10)
-        self.assertEqual(-7 // t10, -7 // 10)
-        self.assertEqual(tm7 // 10, -7 // 10)
+        assert(tm7 // t10, -7 // 10)
+        assert(-7 // t10, -7 // 10)
+        assert(tm7 // 10, -7 // 10)
 
     def test_tclobj_math21(self):
         """exercise tohil.tclobj "inplace floor divide" math ops"""
@@ -260,49 +293,49 @@ class TestTclObj(unittest.TestCase):
 
         t = t66
         t //= 2
-        self.assertEqual(t, 66 // 2)
+        assert(t, 66 // 2)
         t //= r5
-        self.assertEqual(t, 33 // 5)
+        assert(t, 33 // 5)
         t = t66
         t //= tm7
-        self.assertEqual(t, 66 // -7)
+        assert(t, 66 // -7)
 
     def test_tclobj_math22(self):
         """exercise tohil.tclobj inplace remainder ops"""
         t = tohil.tclobj(5)
         t %= 7
-        self.assertEqual(t, 5 % 7)
+        assert(t, 5 % 7)
 
         t = tohil.tclobj(11)
         t %= 5
-        self.assertEqual(t, 11 % 5)
+        assert(t, 11 % 5)
 
         t = tohil.tclobj(77)
         t %= -7
-        self.assertEqual(t, 77 % -7)
+        assert(t, 77 % -7)
 
         t = tohil.tclobj(-77)
         t %= -7
-        self.assertEqual(t, -77 % -7)
+        assert(t, -77 % -7)
 
         t = tohil.tclobj(-77)
         t %= 7
-        self.assertEqual(t, -77 % 7)
+        assert(t, -77 % 7)
 
         t = tohil.tclobj(-77)
         tm7 = tohil.tclobj('-7.')
         t %= tm7
-        self.assertEqual(t, -77 % -7.)
+        assert(t, -77 % -7.)
 
         t = tohil.tclobj(-77.)
         tm7 = tohil.tclobj('-7')
         t %= tm7
-        self.assertEqual(t, -77. % -7)
+        assert(t, -77. % -7)
 
         t = tohil.tclobj(-77.)
         tm7 = tohil.tclobj(-7.)
         t %= tm7
-        self.assertEqual(t, -77. % -7.)
+        assert(t, -77. % -7.)
 
 
 if __name__ == "__main__":

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -380,6 +380,47 @@ class TestTclObj(unittest.TestCase):
         tv %= i
         assert(abs(tv - v % i) < 0.000001)
 
+    def test_tclobj_math26(self):
+        """exercise tohil.tclobj division by zero exceptions"""
+        t5 = tohil.tclobj(5)
+        t0 = tohil.tclobj(0)
+
+        with self.assertRaises(ZeroDivisionError):
+            t5 / 0
+
+        with self.assertRaises(ZeroDivisionError):
+            t5 / t0
+
+        with self.assertRaises(ZeroDivisionError):
+            5 / t0
+
+    def test_tclobj_math27(self):
+        """exercise tohil.tclobj integer division by zero exceptions"""
+        t5 = tohil.tclobj(5)
+        t0 = tohil.tclobj(0)
+
+        with self.assertRaises(ZeroDivisionError):
+            t5 // 0
+
+        with self.assertRaises(ZeroDivisionError):
+            t5 // t0
+
+        with self.assertRaises(ZeroDivisionError):
+            5 // t0
+
+    def test_tclobj_math28(self):
+        """exercise tohil.tclobj integer remainder of by zero exceptions"""
+        t5 = tohil.tclobj(5)
+        t0 = tohil.tclobj(0)
+
+        with self.assertRaises(ZeroDivisionError):
+            t5 % 0
+
+        with self.assertRaises(ZeroDivisionError):
+            t5 % t0
+
+        with self.assertRaises(ZeroDivisionError):
+            5 % t0
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -134,17 +134,17 @@ class TestTclObj(unittest.TestCase):
         assert(i & tj == i & j)
 
     @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
-    def test_tclobj_math10(self, i j):
+    def test_tclobj_math10(self, i, j):
         """exercise tohil.tclobj "or" math ops"""
         ti = tohil.tclobj(i)
         tj = tohil.tclobj(j)
 
-        assert(ti | j, i | j)
-        assert(ti | tj, i | j)
-        assert(i | tj, i | j)
+        assert(ti | j == i | j)
+        assert(ti | tj == i | j)
+        assert(i | tj == i | j)
 
     @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
-    def test_tclobj_math11(self, i j):
+    def test_tclobj_math11(self, i, j):
         """exercise tohil.tclobj "xor" math ops"""
         ti = tohil.tclobj(i)
         tj = tohil.tclobj(j)
@@ -171,7 +171,7 @@ class TestTclObj(unittest.TestCase):
         assert(ti == i + j)
 
     @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
-    def test_tclobj_math13(self):
+    def test_tclobj_math13(self, i, j):
         """exercise tohil.tclobj "inplace subtract" math ops"""
         ti = tohil.tclobj(i)
         tj = tohil.tclobj(j)
@@ -184,7 +184,7 @@ class TestTclObj(unittest.TestCase):
         assert(ti == i - j)
 
     @given(st.integers(-40000, 40000), st.integers(-40000, 40000))
-    def test_tclobj_math14(self, i j):
+    def test_tclobj_math14(self, i, j):
         """exercise tohil.tclobj "inplace multiply" math ops"""
         ti = tohil.tclobj(i)
         tj = tohil.tclobj(j)
@@ -197,145 +197,188 @@ class TestTclObj(unittest.TestCase):
         assert(ti == i * j)
 
 
-    def test_tclobj_math15(self):
+    @given(st.integers(0, 1024), st.integers(0, 23))
+    def test_tclobj_math15(self, i, j):
         """exercise tohil.tclobj "inplace left shift" math ops"""
-        t = tohil.tclobj(7)
-        t5 = tohil.tclobj(2)
 
-        t <<= 2
-        assert(t, 28)
-        t5 <<= t5
-        assert(t5, 8)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-    def test_tclobj_math16(self):
-        """exercise tohil.tclobj "inplace right shift" math ops"""
-        t = tohil.tclobj(32)
-        t5 = tohil.tclobj(2)
+        ti <<= 2
+        assert(ti == i << 2)
 
-        t >>= 1
-        assert(t, 16)
-        t >>= t5
-        assert(t, 4)
+        # shift left by some bits
+        ti = tohil.tclobj(i)
+        ti <<= j
+        assert(ti == i << j)
 
-    def test_tclobj_math16(self):
+        # shift left by some bits, the count provided by a tclobj
+        ti = tohil.tclobj(i)
+        ti <<= tj
+        assert(ti == i << j)
+
+    @given(st.integers(0, 2000000000), st.integers(0, 23))
+    def test_tclobj_math16(self, i, j):
+        """exercise tohil.tclobj right shift math ops"""
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
+
+        ti >>= j
+        assert(ti == i >> j)
+
+        ti = tohil.tclobj(i)
+        ti >>= tj
+        assert(ti == i >> j)
+
+    @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
+    def test_tclobj_math16(self, i, j):
         """exercise tohil.tclobj "inplace bitwise or" math ops"""
-        t = tohil.tclobj(16)
-        t2 = tohil.tclobj(8)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        t |= 32
-        assert(t, 48)
-        t |= t2
-        assert(t, 56)
+        ti |= j
+        assert(ti == i | j)
 
-    def test_tclobj_math17(self):
+        ti = tohil.tclobj(i)
+        ti |= tj
+        assert(ti == i | j)
+
+    @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
+    def test_tclobj_math17(self, i, j):
         """exercise tohil.tclobj "inplace bitwise and" math ops"""
-        t = tohil.tclobj(31)
-        t2 = tohil.tclobj(8)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        t &= 24
-        assert(t, 24)
-        t &= t2
-        assert(t, 8)
+        ti &= j
+        assert(ti == i & j)
 
-    def test_tclobj_math17(self):
+        ti = tohil.tclobj(i)
+        ti &= tj
+        assert(ti == i & j)
+
+    @given(st.integers(0, 2000000000), st.integers(0, 2000000000))
+    def test_tclobj_math17(self, i, j):
         """exercise tohil.tclobj "inplace bitwise xor" math ops"""
-        t = tohil.tclobj(31)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        t ^= 15
-        assert(t, 16)
-        t ^= 17
-        assert(t, 1)
+        ti ^= j
+        assert(ti == i ^ j)
 
-    def test_tclobj_math18(self):
+        ti = tohil.tclobj(i)
+        ti ^= tj
+        assert(ti == i ^ j)
+
+    @given(st.integers(-2000000000, 2000000000), st.integers(-2000000000, 2000000000))
+    def test_tclobj_math18(self, i, j):
         """exercise tohil.tclobj "true divide" math ops"""
-        t = tohil.tclobj(66)
+        assume(j != 0)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        assert(t / 6, 11.0)
-        assert(726 / t, 11.0)
-        assert(t / t, 1.0)
+        assert(ti / j == i / j)
+        assert(ti / tj == i / j)
+        assert(i / tj == i / j)
 
-    def test_tclobj_math19(self):
+    @given(st.integers(-2000000000, 2000000000), st.integers(-2000000000, 2000000000))
+    def test_tclobj_math19(self, i, j):
         """exercise tohil.tclobj "inplace true divide" math ops"""
-        t = tohil.tclobj(66)
+        assume(j != 0)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        t /= 2
-        assert(t, 33.0)
-        j = tohil.tclobj(3)
-        t /= j
-        assert(t, 11.0)
-        j /= j
-        assert(j, 1.0)
+        ti /= j
+        assert(ti == i / j)
 
-    def test_tclobj_math20(self):
+        ti = tohil.tclobj(i)
+        ti /= tj
+        assert(ti == i / j)
+
+    @given(st.integers(-2000000000, 2000000000), st.integers(-2000000000, 2000000000))
+    def test_tclobj_math20(self, i, j):
         """exercise tohil.tclobj "floor divide" math ops"""
-        t66 = tohil.tclobj(66)
-        t10 = tohil.tclobj(10)
-        tm7 = tohil.tclobj(-7)
+        assume(j != 0)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        assert(t66 // t10, 66 // 10)
-        assert(66 // t10, 66 // 10)
-        assert(t66 // 10, 66 // 10)
+        assert(ti // j == i // j)
+        assert(ti // tj == i // j)
+        assert(i // tj == i // j)
 
-        assert(t66 // tm7, 66 // -7)
-        assert(66 // tm7, 66 // -7)
-        assert(t66 // -7, 66 // -7)
+    @given(st.integers(-2000000000, 2000000000), st.integers(-2000000000, 2000000000))
+    def test_tclobj_math21(self, i, j):
+        """exercise tohil.tclobj "inplace floor divide" integer math ops"""
+        assume(j != 0)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        assert(tm7 // t10, -7 // 10)
-        assert(-7 // t10, -7 // 10)
-        assert(tm7 // 10, -7 // 10)
+        ti //= j
+        assert(ti == i // j)
 
-    def test_tclobj_math21(self):
-        """exercise tohil.tclobj "inplace floor divide" math ops"""
-        t66 = tohil.tclobj(66)
-        t10 = tohil.tclobj(10)
-        tm7 = tohil.tclobj(-7)
-        r5 = tohil.tclobj(5)
+        ti = tohil.tclobj(i)
+        ti //= tj
+        assert(ti == i // j)
 
-        t = t66
-        t //= 2
-        assert(t, 66 // 2)
-        t //= r5
-        assert(t, 33 // 5)
-        t = t66
-        t //= tm7
-        assert(t, 66 // -7)
+    @given(st.floats(-2000000000, 2000000000), st.floats(-2000000000, 2000000000))
+    def test_tclobj_math22(self, u, v):
+        """exercise tohil.tclobj "inplace floor divide" float math ops"""
+        assume(v != 0)
+        tu = tohil.tclobj(u)
+        tv = tohil.tclobj(v)
 
-    def test_tclobj_math22(self):
-        """exercise tohil.tclobj inplace remainder ops"""
-        t = tohil.tclobj(5)
-        t %= 7
-        assert(t, 5 % 7)
+        tu //= v
+        assert(tu == u // v)
 
-        t = tohil.tclobj(11)
-        t %= 5
-        assert(t, 11 % 5)
+        tu = tohil.tclobj(u)
+        tu //= tv
+        assert(tu == u // v)
 
-        t = tohil.tclobj(77)
-        t %= -7
-        assert(t, 77 % -7)
+    @given(st.integers(-2000000000, 2000000000), st.integers(-2000000000, 2000000000))
+    def test_tclobj_math23(self, i, j):
+        """exercise tohil.tclobj "inplace remainder" integer math ops"""
+        assume(j != 0)
+        ti = tohil.tclobj(i)
+        tj = tohil.tclobj(j)
 
-        t = tohil.tclobj(-77)
-        t %= -7
-        assert(t, -77 % -7)
+        ti %= j
+        assert(ti == i % j)
 
-        t = tohil.tclobj(-77)
-        t %= 7
-        assert(t, -77 % 7)
+        ti = tohil.tclobj(i)
+        ti %= tj
+        assert(ti == i % j)
 
-        t = tohil.tclobj(-77)
-        tm7 = tohil.tclobj('-7.')
-        t %= tm7
-        assert(t, -77 % -7.)
+    @given(st.floats(-2000000000, 2000000000), st.floats(-2000000000, 2000000000))
+    def test_tclobj_math24(self, u, v):
+        """exercise tohil.tclobj "inplace remainder" float math ops"""
+        assume(v != 0)
+        tu = tohil.tclobj(u)
+        tv = tohil.tclobj(v)
 
-        t = tohil.tclobj(-77.)
-        tm7 = tohil.tclobj('-7')
-        t %= tm7
-        assert(t, -77. % -7)
+        tu %= v
+        assert(tu == u % v)
 
-        t = tohil.tclobj(-77.)
-        tm7 = tohil.tclobj(-7.)
-        t %= tm7
-        assert(t, -77. % -7.)
+        tu = tohil.tclobj(u)
+        tu %= tv
+        assert(tu == u % v)
+
+    @given(st.integers(-2000000000, 2000000000), st.floats(-2000000000, 2000000000))
+    def test_tclobj_math25(self, i, v):
+        """exercise tohil.tclobj "inplace remainder" mixed-type math ops"""
+        assume(v != 0)
+        ti = tohil.tclobj(i)
+        tv = tohil.tclobj(v)
+
+        ti %= v
+        assert(ti == i % v)
+
+        ti = tohil.tclobj(i)
+        ti %= tv
+        assert(ti == i % v)
+
+        assume(i != 0)
+        ti = tohil.tclobj(i)
+        tv %= i
+        assert(tv == v % i)
 
 
 if __name__ == "__main__":

--- a/tests/test_tclobj_math.py
+++ b/tests/test_tclobj_math.py
@@ -288,11 +288,11 @@ class TestTclObj(unittest.TestCase):
         tj = tohil.tclobj(j)
 
         ti /= j
-        assert(ti == i / j)
+        assert(abs(ti - i / j) < 0.000000001)
 
         ti = tohil.tclobj(i)
         ti /= tj
-        assert(ti == i / j)
+        assert(abs(ti - i / j) < 0.000000001)
 
     @given(st.integers(-2000000000, 2000000000), st.integers(-2000000000, 2000000000))
     def test_tclobj_math20(self, i, j):
@@ -355,11 +355,11 @@ class TestTclObj(unittest.TestCase):
         tv = tohil.tclobj(v)
 
         tu %= v
-        assert(tu == u % v)
+        assert(abs(tu - u % v) < 0.000001)
 
         tu = tohil.tclobj(u)
         tu %= tv
-        assert(tu == u % v)
+        assert(abs(tu - u % v) < 0.000001)
 
     @given(st.integers(-2000000000, 2000000000), st.floats(-2000000000, 2000000000))
     def test_tclobj_math25(self, i, v):
@@ -369,16 +369,16 @@ class TestTclObj(unittest.TestCase):
         tv = tohil.tclobj(v)
 
         ti %= v
-        assert(ti == i % v)
+        assert(abs(ti - i % v) < 0.000001)
 
         ti = tohil.tclobj(i)
         ti %= tv
-        assert(ti == i % v)
+        assert(abs(ti - i % v) < 0.000001)
 
         assume(i != 0)
         ti = tohil.tclobj(i)
         tv %= i
-        assert(tv == v % i)
+        assert(abs(tv - v % i) < 0.000001)
 
 
 if __name__ == "__main__":

--- a/tests/test_tclobj_varsync.py
+++ b/tests/test_tclobj_varsync.py
@@ -1,0 +1,76 @@
+
+import tohil
+
+import hypothesis
+from hypothesis import given, strategies as st
+import unittest
+
+tohil.eval("""namespace forget ::tohil_test; namespace eval ::tohil_test {}""")
+
+class TclobjVarsyncTests(unittest.TestCase):
+    @given(st.integers(-1000000000, 1000000000), st.integers(-1000000000, 1000000000))
+    def test_tclobj_varsync1(self, x, y):
+        """test tclobj 'varsync' tcobj shove stuff into tcl and see it from python and vice versa"""
+        ns_name = "::tohil_test"
+        xname = ns_name + "::varsync_x"
+        yname = ns_name + "::varsync_y"
+
+        tx = tohil.tclobj(x, var=xname)
+        ty = tohil.tclobj(y, var=yname)
+
+        # compare the tclobj to tcl via a few different approaches
+        assert tx == x
+        assert tx == tohil.getvar(xname, to=int)
+        assert tx == tohil.eval(f"set {xname}", to=int)
+        assert tx == tohil.eval(f"return ${xname}", to=int)
+        assert tx == tohil.expr(f"${xname}", to=int)
+
+        # mutate tx tclobj and make sure the variable is changing
+        # on the tcl side
+        tx += ty
+        assert tx == tohil.getvar(xname, to=int)
+        assert tx == x + y
+        assert tx == tohil.getvar(xname, to=int)
+        assert tx == x + tohil.getvar(yname, to=int)
+        tx -= ty
+        assert tx == x
+        assert tx == tohil.getvar(xname, to=int)
+
+    @given(st.integers(-1000000000, 1000000000), st.integers(-1000000000, 1000000000))
+    def test_tclobj_varsync2(self, x, y):
+        """test tclobj 'varsync' tcobj shove stuff into tcl and see it from python and vice versa"""
+        ns_name = "::tohil_test"
+        xname = ns_name + "::varsync_x"
+        yname = ns_name + "::varsync_y"
+
+        tx = tohil.tclobj(var=xname)
+        ty = tohil.tclobj(var=yname)
+
+        tohil.eval(f"set {xname} {x}")
+        tohil.eval(f"set {yname} {y}")
+
+        assert tx == tx
+        assert tx == x
+        assert ty == ty
+
+        tohil.incr(xname)
+        assert tx == x + 1
+        assert tx == tohil.expr(f"${xname}")
+        tohil.eval(f"incr {xname} -1")
+        assert tx == x
+
+    @given(st.lists(st.integers(-1000000000, 1000000000)))
+    def test_tclobj_varsync3(self, x):
+        """interoperate python lists back and forth with tcl lists"""
+        ns_name = "::tohil_test"
+        list_name = ns_name + "::varsync_list"
+
+        tl = tohil.tclobj(source=x, var=list_name)
+        assert(str(tl) == tohil.getvar(list_name))
+
+        assert(tl.as_list() == tohil.getvar(list_name, to=list))
+        assert(list(tl) == tohil.getvar(list_name, to=list))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Handle attempted division by zero in divide, floor divide, divmod and remainder by raising a division by zero exception instead of getting a C-level floating point exception, resulting in a SIGFPE.
* Start using the "hypothesis" python testing module for many tests.  Hypothesis is good stuff™.  We already found and fixed some problems because of it.