### PR TITLE
Tcldict and tclobj improvements

### DIFF
--- a/KNOTES.md
+++ b/KNOTES.md
@@ -250,6 +250,26 @@ we already have t.setvar() and t.getvar() to manually sync
 
 
 
+### custom building python on linux
+
+apt install libbz2-dev libgdbm-dev liblzma-dev uuid-dev libffi-dev
+
+sudo apt-get install build-essential libsqlite3-dev sqlite3 bzip2 libbz2-dev zlib1g-dev libssl-dev openssl libgdbm-dev libgdbm-compat-dev liblzma-dev libreadline-dev libncursesw5-dev libffi-dev uuid-dev
+
+./configure --prefix=/opt --enable-ipv6 --with-pydebug --with-trace-refs --with-pymalloc
+
+make
+sudo make install
+
+
+----
+
+trying to build python debug in /opt and link to it from tohil
+
+setuptools seems to be still referencing /usr
+
+PATH=/opt/bin:$PATH
+./configure --prefix=/opt --with-python-version=3.9d --enable-symbols
 
 
 -----

--- a/Makefile.in
+++ b/Makefile.in
@@ -458,7 +458,7 @@ build-python-module:
 	python3 setup.py build
 
 install-python-module:
-	python3 setup.py install
+	python3 setup.py install --prefix=$(prefix)
 
 clean-python-module:
 	rm -rf build/ dist/ pysrc/tohil.egg-info/ tests/__pycache__/

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -54,8 +54,6 @@ static int TohilTclObj_stuff_var(TohilTclObj *self, Tcl_Obj *obj);
 
 PyObject *tohil_python_return(Tcl_Interp *, int tcl_result, PyTypeObject *toType, Tcl_Obj *resultObj);
 
-static PyObject *Tohil_TD_iter_repr(_PyDictViewObject *dv);
-
 // TCL library begins here
 
 // maintain a pointer to the tcl interp - we need it from our stuff python calls where
@@ -1968,7 +1966,6 @@ static PyTypeObject TohilTclObj_IterType = {
     .tp_dealloc = (destructor)TohilTclObjIter_dealloc,
     .tp_iter = (getiterfunc)TohilTclObjIter,
     .tp_iternext = (iternextfunc)TohilTclObj_iternext,
-    //.tp_repr = (reprfunc)Tohil_TD_iter_repr,
 };
 
 //

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1139,10 +1139,10 @@ TohilTclObj_richcompare(TohilTclObj *self, PyObject *other, int op)
 }
 
 //
-// tclobj.reset() - reset a tclobj or tcldict to an empty tcl object
+// tclobj.clear() - clear a tclobj or tcldict to an empty tcl object
 //
 static PyObject *
-TohilTclObj_reset(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
+TohilTclObj_clear(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     if (self->tclvar != NULL) {
         Tcl_DecrRefCount(self->tclvar);
@@ -2875,7 +2875,7 @@ static PySequenceMethods TohilTclObj_as_sequence = {
 
 static PyMethodDef TohilTclObj_methods[] = {
     {"__getitem__", (PyCFunction)TohilTclObj_subscript, METH_O | METH_COEXIST, "x.__getitem__(y) <==> x[y]"},
-    {"reset", (PyCFunction)TohilTclObj_reset, METH_NOARGS, "reset the tclobj"},
+    {"clear", (PyCFunction)TohilTclObj_clear, METH_NOARGS, "empty the tclobj"},
     {"as_list", (PyCFunction)TohilTclObj_as_list, METH_NOARGS, "return tclobj as list"},
     {"as_set", (PyCFunction)TohilTclObj_as_set, METH_NOARGS, "return tclobj as set"},
     {"as_tuple", (PyCFunction)TohilTclObj_as_tuple, METH_NOARGS, "return tclobj as tuple"},
@@ -3370,6 +3370,7 @@ static PyMethodDef TohilTclDict_methods[] = {
     {"getvar", (PyCFunction)TohilTclObj_getvar, METH_O, "set tclobj to tcl var or array element"},
     {"setvar", (PyCFunction)TohilTclObj_setvar, METH_O, "set tcl var or array element to tclobj's tcl object"},
     {"set", (PyCFunction)TohilTclObj_set, METH_O, "set tclobj from some python object"},
+    {"clear", (PyCFunction)TohilTclObj_clear, METH_NOARGS, "remove all items from the tcl dict"},
     {NULL} // sentinel
 };
 

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1618,7 +1618,7 @@ TohilTclObj_pop(TohilTclObj *self, PyObject *args, PyObject *kwargs)
     }
     printf("replaced the element\n");
 
-    if (TohilTclObj_possibly_stuff_var(self, resultObj) < 0)
+    if (TohilTclObj_possibly_stuff_var(self, selfobj) < 0)
         return NULL;
 
     if (to == NULL && self->to != NULL)

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2041,7 +2041,6 @@ Tohil_TD_items_iternext(Tohil_TD_IterObj *self)
     return Tohil_TD_multi_iternext(self, Items);
 }
 
-
 static PyTypeObject Tohil_TD_IterType = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_iter",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
@@ -2051,7 +2050,7 @@ static PyTypeObject Tohil_TD_IterType = {
     .tp_iternext = (iternextfunc)Tohil_TD_iternext,
 };
 
-static PyTypeObject Tohil_TD_KeysType = {
+static PyTypeObject Tohil_TD_IterKeysType = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_keys",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
@@ -2060,7 +2059,7 @@ static PyTypeObject Tohil_TD_KeysType = {
     .tp_iternext = (iternextfunc)Tohil_TD_keys_iternext,
 };
 
-static PyTypeObject Tohil_TD_ValuesType = {
+static PyTypeObject Tohil_TD_IterValuesType = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_values",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
@@ -2069,7 +2068,7 @@ static PyTypeObject Tohil_TD_ValuesType = {
     .tp_iternext = (iternextfunc)Tohil_TD_values_iternext,
 };
 
-static PyTypeObject Tohil_TD_ItemsType = {
+static PyTypeObject Tohil_TD_IterItemsType = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_items",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
@@ -3191,19 +3190,19 @@ TohilTclDictIter(TohilTclObj *self)
 static PyObject *
 TohilTclDict_keys_new(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
-    return TohilTclDictIter_new(self, &Tohil_TD_KeysType);
+    return TohilTclDictIter_new(self, &Tohil_TD_IterKeysType);
 }
 
 static PyObject *
 TohilTclDict_values_new(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
-    return TohilTclDictIter_new(self, &Tohil_TD_ValuesType);
+    return TohilTclDictIter_new(self, &Tohil_TD_IterValuesType);
 }
 
 static PyObject *
 TohilTclDict_items_new(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
-    return TohilTclDictIter_new(self, &Tohil_TD_ItemsType);
+    return TohilTclDictIter_new(self, &Tohil_TD_IterItemsType);
 }
 
 //
@@ -3906,15 +3905,15 @@ PyInit__tohil(void)
     }
 
     // turn up the tcldict keys, items and values iterator types
-    if (PyType_Ready(&Tohil_TD_KeysType) < 0) {
+    if (PyType_Ready(&Tohil_TD_IterKeysType) < 0) {
         return NULL;
     }
 
-    if (PyType_Ready(&Tohil_TD_ItemsType) < 0) {
+    if (PyType_Ready(&Tohil_TD_IterItemsType) < 0) {
         return NULL;
     }
 
-    if (PyType_Ready(&Tohil_TD_ValuesType) < 0) {
+    if (PyType_Ready(&Tohil_TD_IterValuesType) < 0) {
         return NULL;
     }
 

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2041,38 +2041,55 @@ Tohil_TD_items_iternext(Tohil_TD_IterObj *self)
     return Tohil_TD_multi_iternext(self, Items);
 }
 
+//
+// deallocate function for python tcldict iter object types
+//
+static void
+TohilTclDictIter_dealloc(Tohil_TD_IterObj *self)
+{
+    // NB we need to do var shadowing with tcldicts too
+    if (self->dictObj != NULL)
+        Tcl_DecrRefCount(self->dictObj);
+    Py_XDECREF(self->to);
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
 static PyTypeObject Tohil_TD_IterType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_iter",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil_td_iter",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD iterator type",
+    .tp_dealloc = (destructor)TohilTclDictIter_dealloc,
     .tp_iter = (getiterfunc)Tohil_TD_iter,
     .tp_iternext = (iternextfunc)Tohil_TD_iternext,
 };
 
 static PyTypeObject Tohil_TD_IterKeysType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_keys",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil_td_keys_iter",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD keys iterator object",
+    .tp_dealloc = (destructor)TohilTclDictIter_dealloc,
     .tp_iter = (getiterfunc)Tohil_TD_iter,
     .tp_iternext = (iternextfunc)Tohil_TD_keys_iternext,
 };
 
 static PyTypeObject Tohil_TD_IterValuesType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_values",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_values_iter",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD values iterator object",
+    .tp_dealloc = (destructor)TohilTclDictIter_dealloc,
     .tp_iter = (getiterfunc)Tohil_TD_iter,
     .tp_iternext = (iternextfunc)Tohil_TD_values_iternext,
 };
 
 static PyTypeObject Tohil_TD_IterItemsType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_items",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_items_iter",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD items iterator object",
+    .tp_dealloc = (destructor)TohilTclDictIter_dealloc,
     .tp_iter = (getiterfunc)Tohil_TD_iter,
     .tp_iternext = (iternextfunc)Tohil_TD_items_iternext,
 };
@@ -3204,6 +3221,7 @@ TohilTclDict_items_new(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     return TohilTclDictIter_new(self, &Tohil_TD_IterItemsType);
 }
+
 
 //
 // TohilTclDict_Contains - return 0 if key or keys is not

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2886,8 +2886,8 @@ static PyMethodDef TohilTclObj_methods[] = {
     {"setvar", (PyCFunction)TohilTclObj_setvar, METH_O, "set tcl var or array element to tclobj's tcl object"},
     {"set", (PyCFunction)TohilTclObj_set, METH_O, "set tclobj from some python object"},
     {"lindex", (PyCFunction)TohilTclObj_lindex, METH_VARARGS | METH_KEYWORDS, "get value from tclobj as tcl list"},
-    {"lappend", (PyCFunction)TohilTclObj_lappend, METH_O, "lappend (list-append) something to tclobj"},
-    {"lappend_list", (PyCFunction)TohilTclObj_lappend_list, METH_O, "lappend another tclobj or a python list of stuff to tclobj"},
+    {"append", (PyCFunction)TohilTclObj_lappend, METH_O, "lappend (list-append) something to tclobj"},
+    {"extend", (PyCFunction)TohilTclObj_lappend_list, METH_O, "lappend another tclobj or a python list of stuff to tclobj"},
     {NULL} // sentinel
 };
 

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1142,7 +1142,7 @@ TohilTclObj_richcompare(TohilTclObj *self, PyObject *other, int op)
 // tclobj.reset() - reset a tclobj or tcldict to an empty tcl object
 //
 static PyObject *
-TohilTclObj_reset(TohilTclObj *self, PyObject *pyobj)
+TohilTclObj_reset(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     if (self->tclvar != NULL) {
         Tcl_DecrRefCount(self->tclvar);
@@ -1164,7 +1164,7 @@ TohilTclObj_reset(TohilTclObj *self, PyObject *pyobj)
 // tclobj.as_list()
 //
 static PyObject *
-TohilTclObj_as_list(TohilTclObj *self, PyObject *pyobj)
+TohilTclObj_as_list(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     Tcl_Obj *selfobj = TohilTclObj_objptr(self);
     if (selfobj == NULL)
@@ -1176,7 +1176,7 @@ TohilTclObj_as_list(TohilTclObj *self, PyObject *pyobj)
 // tclobj.as_set()
 //
 static PyObject *
-TohilTclObj_as_set(TohilTclObj *self, PyObject *pyobj)
+TohilTclObj_as_set(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     Tcl_Obj *selfobj = TohilTclObj_objptr(self);
     if (selfobj == NULL)
@@ -1188,7 +1188,7 @@ TohilTclObj_as_set(TohilTclObj *self, PyObject *pyobj)
 // tclobj.as_tuple()
 //
 static PyObject *
-TohilTclObj_as_tuple(TohilTclObj *self, PyObject *pyobj)
+TohilTclObj_as_tuple(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     Tcl_Obj *selfobj = TohilTclObj_objptr(self);
     if (selfobj == NULL)
@@ -1200,7 +1200,7 @@ TohilTclObj_as_tuple(TohilTclObj *self, PyObject *pyobj)
 // tclobj.as_dict()
 //
 static PyObject *
-TohilTclObj_as_dict(TohilTclObj *self, PyObject *pyobj)
+TohilTclObj_as_dict(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     Tcl_Obj *selfobj = TohilTclObj_objptr(self);
     if (selfobj == NULL)
@@ -1212,7 +1212,7 @@ TohilTclObj_as_dict(TohilTclObj *self, PyObject *pyobj)
 // tclobj.as_tclobj()
 //
 static PyObject *
-TohilTclObj_as_tclobj(TohilTclObj *self, PyObject *pyobj)
+TohilTclObj_as_tclobj(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     Tcl_Obj *selfobj = TohilTclObj_objptr(self);
     if (selfobj == NULL)
@@ -1224,7 +1224,7 @@ TohilTclObj_as_tclobj(TohilTclObj *self, PyObject *pyobj)
 // tclobj.as_tcldict()
 //
 static PyObject *
-TohilTclObj_as_tcldict(TohilTclObj *self, PyObject *pyobj)
+TohilTclObj_as_tcldict(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     Tcl_Obj *selfobj = TohilTclObj_objptr(self);
     if (selfobj == NULL)
@@ -1236,7 +1236,7 @@ TohilTclObj_as_tcldict(TohilTclObj *self, PyObject *pyobj)
 // tclobj.as_byte_array()
 //
 static PyObject *
-TohilTclObj_as_byte_array(TohilTclObj *self, PyObject *pyobj)
+TohilTclObj_as_byte_array(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     int size;
     Tcl_Obj *selfobj = TohilTclObj_objptr(self);
@@ -1525,7 +1525,7 @@ TohilTclObj_lappend_list(TohilTclObj *self, PyObject *pObject)
 //   tclobj or tcldict's internal tcl object
 //
 static PyObject *
-TohilTclObj_refcount(TohilTclObj *self, PyObject *dummy)
+TohilTclObj_refcount(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     Tcl_Obj *obj = TohilTclObj_objptr(self);
     if (obj == NULL)
@@ -1538,7 +1538,7 @@ TohilTclObj_refcount(TohilTclObj *self, PyObject *dummy)
 //   tclobj or tcldict object
 //
 static PyObject *
-TohilTclObj_pyrefcount(TohilTclObj *self, PyObject *dummy)
+TohilTclObj_pyrefcount(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromLong(Py_REFCNT(self));
 }
@@ -1552,7 +1552,7 @@ TohilTclObj_pyrefcount(TohilTclObj *self, PyObject *dummy)
 //   hasn't been used as a list, dict, etc.
 //
 static PyObject *
-TohilTclObj_type(TohilTclObj *self, PyObject *dummy)
+TohilTclObj_type(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     Tcl_Obj *obj = TohilTclObj_objptr(self);
     if (obj == NULL)
@@ -3063,7 +3063,7 @@ TohilTclDict_length(TohilTclObj *self)
 //   returns null i.e. exception thrown if tcl object isn't a proper tcl dict.
 //
 static PyObject *
-TohilTclDict_size(TohilTclObj *self, PyObject *pyobj)
+TohilTclDict_size(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 {
     int length = TohilTclDict_length(self);
     if (length < 0) {

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1601,30 +1601,30 @@ TohilTclObj_pop(TohilTclObj *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
-    printf("element %d of size %d\n", i, size);
-
     // get the item
     Tcl_Obj *resultObj = NULL;
     if (Tcl_ListObjIndex(self->interp, selfobj, i, &resultObj) == TCL_ERROR) {
         PyErr_SetString(PyExc_TypeError, Tcl_GetString(Tcl_GetObjResult(self->interp)));
         return NULL;
     }
-    printf("got the item\n");
+    Tcl_IncrRefCount(resultObj);
+
+    if (Tcl_IsShared(selfobj)) {
+        Tcl_DecrRefCount(selfobj);
+        selfobj = Tcl_DuplicateObj(selfobj);
+    }
 
     // remove the item for the list
     if (Tcl_ListObjReplace(self->interp, selfobj, i, 1, 0, NULL) == TCL_ERROR) {
         PyErr_SetString(PyExc_IndexError, Tcl_GetString(Tcl_GetObjResult(self->interp)));
         return NULL;
     }
-    printf("replaced the element\n");
-
     if (TohilTclObj_possibly_stuff_var(self, selfobj) < 0)
         return NULL;
 
     if (to == NULL && self->to != NULL)
         to = self->to;
 
-    printf("stuffed var and returning\n");
     return tohil_python_return(self->interp, TCL_OK, to, resultObj);
 }
 

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2041,6 +2041,29 @@ Tohil_TD_items_iternext(Tohil_TD_IterObj *self)
     return Tohil_TD_multi_iternext(self, Items);
 }
 
+static PyObject *
+Tohil_TD_iter_repr(_PyDictViewObject *dv)
+{
+    PyObject *seq;
+    PyObject *result = NULL;
+    Py_ssize_t rc;
+
+    rc = Py_ReprEnter((PyObject *)dv);
+    if (rc != 0) {
+        return rc > 0 ? PyUnicode_FromString("...") : NULL;
+    }
+    seq = PySequence_List((PyObject *)dv);
+    if (seq == NULL) {
+        goto Done;
+    }
+    result = PyUnicode_FromFormat("%s(%R)", Py_TYPE(dv)->tp_name, seq);
+    Py_DECREF(seq);
+
+Done:
+    Py_ReprLeave((PyObject *)dv);
+    return result;
+}
+
 //
 // deallocate function for python tcldict iter object types
 //
@@ -2062,36 +2085,40 @@ static PyTypeObject Tohil_TD_IterType = {
     .tp_dealloc = (destructor)TohilTclDictIter_dealloc,
     .tp_iter = (getiterfunc)Tohil_TD_iter,
     .tp_iternext = (iternextfunc)Tohil_TD_iternext,
+    .tp_repr = (reprfunc)Tohil_TD_iter_repr,
 };
 
 static PyTypeObject Tohil_TD_IterKeysType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil_td_keys_iter",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil_td_keys",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD keys iterator object",
     .tp_dealloc = (destructor)TohilTclDictIter_dealloc,
     .tp_iter = (getiterfunc)Tohil_TD_iter,
     .tp_iternext = (iternextfunc)Tohil_TD_keys_iternext,
+    .tp_repr = (reprfunc)Tohil_TD_iter_repr,
 };
 
 static PyTypeObject Tohil_TD_IterValuesType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_values_iter",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil_td_values",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD values iterator object",
     .tp_dealloc = (destructor)TohilTclDictIter_dealloc,
     .tp_iter = (getiterfunc)Tohil_TD_iter,
     .tp_iternext = (iternextfunc)Tohil_TD_values_iternext,
+    .tp_repr = (reprfunc)Tohil_TD_iter_repr,
 };
 
 static PyTypeObject Tohil_TD_IterItemsType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil._td_items_iter",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil_td_items",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD items iterator object",
     .tp_dealloc = (destructor)TohilTclDictIter_dealloc,
     .tp_iter = (getiterfunc)Tohil_TD_iter,
     .tp_iternext = (iternextfunc)Tohil_TD_items_iternext,
+    .tp_repr = (reprfunc)Tohil_TD_iter_repr,
 };
 
 //

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -3134,6 +3134,7 @@ static PySequenceMethods TohilTclDict_as_sequence = {
 };
 
 static PyMethodDef TohilTclDict_methods[] = {
+    {"__getitem__", (PyCFunction)(void(*)(void))TohilTclDict_subscript, METH_O | METH_COEXIST, "x.__getitem__(y) <==> x[y]"},
     {"get", (PyCFunction)TohilTclDict_td_get, METH_VARARGS | METH_KEYWORDS, "get from tcl dict"},
     // NB i don't know if this __len__ thing works -- python might
     // be doing something gross to get the len of the dict, like

--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -75,29 +75,6 @@ def interact():
     call("commandloop", "-prompt1", 'return  " % "', "-prompt2", 'return "> "')
 
 
-### tclobj iterator
-
-
-class TclObjIterator:
-    """tclobj iterator - one of these is returned by tclobj
-    iter function to iterate over a tclobj"""
-
-    def __init__(self, tclobj):
-        self.tclobj = tclobj
-        self.index = -1
-
-    def __iter__(self):
-        self.index = -1
-        return self
-
-    def __next__(self):
-        self.index += 1
-        if self.index >= len(self.tclobj):
-            raise StopIteration
-
-        return self.tclobj.lindex(self.index)
-
-
 ### shadow dictionaries
 
 

--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -99,15 +99,14 @@ class ShadowDictIterator:
 class ShadowDict(MutableMapping):
     """shadow dicts - python dict-like objects that shadow a tcl array"""
 
-    def __init__(self, tcl_array, **kwargs):
+    def __init__(self, tcl_array, *, default=None, to=None):
         self.tcl_array = tcl_array
-        if "to" in kwargs:
-            self.to_type = kwargs["to"]
-        else:
+        if to is None:
             self.to_type = str
+        else:
+            self.to_type = to
 
-        if "default" in kwargs:
-            self.default = kwargs["default"]
+        self.default = default
 
     def __getitem__(self, key):
         """access element of the shadow dict using the [] notation"""
@@ -142,29 +141,20 @@ class ShadowDict(MutableMapping):
         """return true if the shadow dict has an element named key, else false"""
         return exists(f"{self.tcl_array}({key})")
 
-    def get(self, key, **kwargs):
-        """return the value of an element of the shadow dict, with conversion
-        to the specified type, and with a default value from an argument to
-        get or if not that, a default value from the shadow dict object specified
-        at shadow dict creation time
+    def clear(self):
+        """remove all items from the shadow dictionary (unset the tcl array)"""
+        call("array", "unset", self.tcl_array)
 
-        likewise 'to' conversion can be specified when creating the object or in
-        the call to 'get', with the args to get having the higher priority"""
-        if "to" in kwargs:
-            to = kwargs["to"]
-        else:
+    def get(self, key, default=None, *, to=None):
+        """return the value of an element of the shadow dict, with conversion
+        to the specified type, if key is present in the tcl array.  if default
+        is not given, it defaults to None, so this method never raises a KeyError."""
+
+        if to is None:
             to = self.to_type
         if exists(f"{self.tcl_array}({key})"):
             return getvar(f"{self.tcl_array}({key})", to=to)
-        if "default" in kwargs:
-            return convert(kwargs["default"], to=to)
-        try:
-            self.default
-            return convert(self.default, to=to)
-        except NameError:
-            raise TypeError(
-                f"element '{key}' doesn't exist in tcl array '{self.tcl_array}', and no default was specified to 'get' or to ShadowDict()"
-            )
+        return convert(default, to=to)
 
 #
 # misc stuff and helpers

--- a/tests/test_shadowdict.py
+++ b/tests/test_shadowdict.py
@@ -45,6 +45,15 @@ class TestShadowDicts(unittest.TestCase):
         self.assertEqual(x.get('nonesuch', 0), 0)
         self.assertEqual(x.get('nonesuch', default=16), 16)
 
+    def test_shadowdict7(self):
+        """pop elements from shadow dict, with and without
+        specified defaults"""
+        tohil.eval("array set x [list a 1 b 2 c 3 d 4]")
+        x = tohil.ShadowDict("x", to=int)
+        self.assertEqual(x.pop('e', 5), 5)
+        self.assertEqual(x.pop('d'), 4)
+        self.assertEqual(x.pop('c', 4), 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_shadowdict.py
+++ b/tests/test_shadowdict.py
@@ -32,6 +32,19 @@ class TestShadowDicts(unittest.TestCase):
         del x["d"]
         self.assertEqual(len(x), 4)
 
+    def test_shadowdict6(self):
+        """get element from shadow dict, with and without
+        specified defaults"""
+        tohil.eval("array set x [list a 1 b 2 c 3 d 4]")
+        x = tohil.ShadowDict("x", to=int)
+        self.assertEqual(x.get('d'), 4)
+        self.assertEqual(x.get('d', 'defval'), 4)
+        self.assertEqual(x.get('d', default='defval'), 4)
+        self.assertEqual(x.get('nonesuch', to=str), '')
+        self.assertEqual(x.get('nonesuch', 'defval', to=str), 'defval')
+        self.assertEqual(x.get('nonesuch', 0), 0)
+        self.assertEqual(x.get('nonesuch', default=16), 16)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tclobj.py
+++ b/tests/test_tclobj.py
@@ -35,6 +35,7 @@ class TestTclObj(unittest.TestCase):
         x = tohil.eval("list 1 2 3 4 5", to=tohil.tclobj)
 
         self.assertEqual(x.as_list(), ["1", "2", "3", "4", "5"])
+        self.assertEqual(list(x), ["1", "2", "3", "4", "5"])
 
     def test_tclobj5(self):
         """exercise tohil.tclobj as_set()"""
@@ -63,10 +64,10 @@ class TestTclObj(unittest.TestCase):
         self.assertEqual(str(x), tohil.getvar("foo"))
 
     def test_tclobj9(self):
-        """exercise tohil.tclobj reset()"""
+        """exercise tohil.tclobj clear()"""
         x = tohil.eval("list 1 2 3 4 5", to=tohil.tclobj)
         self.assertEqual(str(x), "1 2 3 4 5")
-        x.reset()
+        x.clear()
         self.assertEqual(str(x), "")
 
     def test_tclobj10(self):

--- a/tests/test_tclobj.py
+++ b/tests/test_tclobj.py
@@ -79,17 +79,17 @@ class TestTclObj(unittest.TestCase):
         self.assertEqual(repr(x[2]), "<tohil.tclobj: '3'>")
 
     def test_tclobj11(self):
-        """exercise tohil.tclobj lappend()"""
+        """exercise tohil.tclobj append()"""
         x = tohil.eval("list 1 2 3 4 5", to=tohil.tclobj)
-        x.lappend("6")
-        x.lappend(7)
+        x.append("6")
+        x.append(7)
         self.assertEqual(str(x), "1 2 3 4 5 6 7")
 
     def test_tclobj12(self):
         """exercise tohil.tclobj as_byte_array()"""
         x = tohil.eval("list 1 2 3 4 5", to=tohil.tclobj)
-        x.lappend("6")
-        x.lappend(7)
+        x.append("6")
+        x.append(7)
         self.assertEqual(x.as_byte_array(), bytearray(b"1 2 3 4 5 6 7"))
 
     def test_tclobj13(self):
@@ -180,16 +180,16 @@ class TestTclObj(unittest.TestCase):
         self.assertFalse(x[2] > 4.0)
 
     def test_tclobj19(self):
-        """tohil.tclobj lappend_list"""
+        """tohil.tclobj extend (lappend ... {*})"""
         x = tohil.eval("list 1 2 3 4 5 6", to=tohil.tclobj)
         y = tohil.eval("list 7 8 9", to=tohil.tclobj)
-        x.lappend(y)
+        x.append(y)
         self.assertEqual(repr(x), "<tohil.tclobj: '1 2 3 4 5 6 {7 8 9}'>")
         x = tohil.eval("list 1 2 3 4 5 6", to=tohil.tclobj)
-        x.lappend_list(y)
+        x.extend(y)
         self.assertEqual(repr(x), "<tohil.tclobj: '1 2 3 4 5 6 7 8 9'>")
         l = [10, 11, 12, 13]
-        x.lappend_list(l)
+        x.extend(l)
         self.assertEqual(repr(x), "<tohil.tclobj: '1 2 3 4 5 6 7 8 9 10 11 12 13'>")
 
     def test_tclobj20(self):

--- a/tests/test_td.py
+++ b/tests/test_td.py
@@ -17,7 +17,7 @@ class TestTD(unittest.TestCase):
         x.to = str
         self.assertEqual(x.get("z", default="bar"), "bar")
         self.assertEqual(x.get("z", default="bar", to=list), ["bar"])
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             x.get("z", default="bar", to=int)
         self.assertEqual(x.get("z", default="1", to=int), 1)
 


### PR DESCRIPTION
* .reset() method renamed to .clear() for conformance with the rest of python.
* Likewise .lappend() and .lappend_list() were renamed to .append() and .extend().
* New .pop() method for tclobjs
* New __getitem__ method for tcldict.
* tcldict.keys(), .values() and .items() sort of works but not really insofar as they are not mutable.
* really nice repr() function for tcldict iterators
* Make ShadowDicts behave more like dicts
* conform ShadowDict "get" method to behave like dict's does, i.e.
  has optional default argument, returns None if key isn't there and
  default isn't specified.
* new "clear" method removes all items from the shadow dictionary, i.e.
  unsets the tcl array.