### PR TITLE
Use stdlib for Python keyword check

### DIFF
--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -2,6 +2,7 @@
 
 from collections.abc import MutableMapping
 from io import StringIO
+import keyword
 import sys
 import traceback
 import types
@@ -558,21 +559,7 @@ class TclNamespace:
 
     """
 
-    proc_excluder = (
-        "break",
-        "continue",
-        "for",
-        "global",
-        "if",
-        "return",
-        "try",
-        "while",
-        "yield",
-        "with",
-        "is",
-        "import",
-        "class",
-    )
+    proc_excluder = keyword.kwlist
 
     def __init__(self, namespace):
         # print(f"{self} importing namespace '{namespace}'")


### PR DESCRIPTION
Catches a broader list and shouldn't require maintenance down the line.