### PR TITLE
Multiphase init

### DIFF
--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -59,6 +59,14 @@ static int Tohil_ReturnExceptionToTcl(Tcl_Interp *interp, char *description);
 
 static PyObject *tohil_python_return(Tcl_Interp *, int tcl_result, PyTypeObject *toType, Tcl_Obj *resultObj);
 
+
+
+typedef struct {
+    Tcl_Interp *tcl_interp;
+    PyObject *handle_exception_function;
+    PyObject *error_class;
+} TohilModuleState;
+
 // TCL library begins here
 
 // maintain a pointer to the tcl interp - we need it from our stuff python calls where
@@ -3941,14 +3949,11 @@ static PyMethodDef TohilMethods[] = {
 // TODO: there should probably be some tcl deinit in the clear/free code
 static struct PyModuleDef TohilModule = {
     PyModuleDef_HEAD_INIT,
-    "tohil",
-    "A module to permit interop with Tcl",
-    -1,
-    TohilMethods,
-    NULL, // m_slots
-    NULL, // m_traverse
-    NULL, // m_clear
-    NULL, // m_free
+    .m_name = "tohil",
+    .m_doc= "A module to permit interop with Tcl",
+    .m_size = sizeof(TohilModuleState),
+    .m_methods = TohilMethods,
+    .m_slots = NULL,
 };
 
 /* Shared initialisation begins here */

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1837,7 +1837,7 @@ TohilTclObj_concat(TohilTclObj *self, PyObject *item)
     if (TohilTclObj_Check(item)) {
         tItem = TohilTclObj_objptr((TohilTclObj *)item);
     } else {
-        tItem = _pyObjToTcl(tcl_interp, item);
+        tItem = _pyObjToTcl(self->interp, item);
         if (tItem == NULL)
             Py_RETURN_NOTIMPLEMENTED;
     }
@@ -1870,7 +1870,7 @@ TohilTclObj_inplace_concat(TohilTclObj *self, PyObject *item)
         if (tItem == NULL)
             return NULL;
     } else {
-        tItem = _pyObjToTcl(tcl_interp, item);
+        tItem = _pyObjToTcl(self->interp, item);
         if (tItem == NULL)
             Py_RETURN_NOTIMPLEMENTED;
     }
@@ -2121,7 +2121,7 @@ Tohil_TD_multi_iternext(Tohil_TD_IterObj *self, enum td_itertype itertype)
     if (self->started == 0) {
         self->started = 1;
         // substitute &valueObj for NULL below if you also want the value
-        if (Tcl_DictObjFirst(tcl_interp, self->dictObj, &self->search, &keyObj, &valueObj, &done) == TCL_ERROR) {
+        if (Tcl_DictObjFirst(self->interp, self->dictObj, &self->search, &keyObj, &valueObj, &done) == TCL_ERROR) {
             PyErr_Format(PyExc_TypeError, "tclobj contents cannot be converted into a td");
             return NULL;
         }
@@ -2151,7 +2151,7 @@ Tohil_TD_multi_iternext(Tohil_TD_IterObj *self, enum td_itertype itertype)
         }
 
         if (tohil_TclToUTF8(tclString, tclStringSize, &utf8string, &utf8len) != TCL_OK) {
-            PyErr_SetString(PyExc_RuntimeError, Tcl_GetString(Tcl_GetObjResult(tcl_interp)));
+            PyErr_SetString(PyExc_RuntimeError, Tcl_GetString(Tcl_GetObjResult(self->interp)));
             return NULL;
         }
         PyObject *pObj = Py_BuildValue("s#", utf8string, utf8len);
@@ -2166,7 +2166,7 @@ Tohil_TD_multi_iternext(Tohil_TD_IterObj *self, enum td_itertype itertype)
     char *tclString = Tcl_GetStringFromObj(keyObj, &tclStringSize);
 
     if (tohil_TclToUTF8(tclString, tclStringSize, &utf8string, &utf8len) != TCL_OK) {
-        PyErr_SetString(PyExc_RuntimeError, Tcl_GetString(Tcl_GetObjResult(tcl_interp)));
+        PyErr_SetString(PyExc_RuntimeError, Tcl_GetString(Tcl_GetObjResult(self->interp)));
         return NULL;
     }
     PyTuple_SET_ITEM(pRetTuple, 0, Py_BuildValue("s#", utf8string, utf8len));
@@ -2176,13 +2176,13 @@ Tohil_TD_multi_iternext(Tohil_TD_IterObj *self, enum td_itertype itertype)
         // no "to" specified, stuff the value into item 1 of the tuple
         tclString = Tcl_GetStringFromObj(valueObj, &tclStringSize);
         if (tohil_TclToUTF8(tclString, tclStringSize, &utf8string, &utf8len) != TCL_OK) {
-            PyErr_SetString(PyExc_RuntimeError, Tcl_GetString(Tcl_GetObjResult(tcl_interp)));
+            PyErr_SetString(PyExc_RuntimeError, Tcl_GetString(Tcl_GetObjResult(self->interp)));
             return NULL;
         }
         PyTuple_SET_ITEM(pRetTuple, 1, Py_BuildValue("s#", utf8string, utf8len));
         ckfree(utf8string);
     } else {
-        PyTuple_SET_ITEM(pRetTuple, 1, tohil_python_return(tcl_interp, TCL_OK, self->to, valueObj));
+        PyTuple_SET_ITEM(pRetTuple, 1, tohil_python_return(self->interp, TCL_OK, self->to, valueObj));
     }
 
     return pRetTuple;

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -598,11 +598,7 @@ Tohil_ReturnExceptionToTcl(Tcl_Interp *interp, char *description)
 //   slamming stuff through eval
 //
 static int
-TohilCall_Cmd(ClientData clientData, /* Not used. */
-              Tcl_Interp *interp,    /* Current interpreter */
-              int objc,              /* Number of arguments */
-              Tcl_Obj *const objv[]  /* Argument strings */
-)
+TohilCall_Cmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     if (objc < 2) {
     wrongargs:
@@ -715,11 +711,7 @@ TohilCall_Cmd(ClientData clientData, /* Not used. */
 //   into the python interpreter.
 //
 static int
-TohilImport_Cmd(ClientData clientData, /* Not used. */
-                Tcl_Interp *interp,    /* Current interpreter */
-                int objc,              /* Number of arguments */
-                Tcl_Obj *const objv[]  /* Argument strings */
-)
+TohilImport_Cmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     const char *modname, *topmodname;
     PyObject *pMainModule, *pTopModule;
@@ -756,11 +748,7 @@ TohilImport_Cmd(ClientData clientData, /* Not used. */
 }
 
 static int
-TohilEval_Cmd(ClientData clientData, /* Not used. */
-              Tcl_Interp *interp,    /* Current interpreter */
-              int objc,              /* Number of arguments */
-              Tcl_Obj *const objv[]  /* Argument strings */
-)
+TohilEval_Cmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     if (objc != 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "evalString");
@@ -796,11 +784,7 @@ TohilEval_Cmd(ClientData clientData, /* Not used. */
 // awfully similar to TohilEval_Cmd above
 // but expecting to do more like capture stdout
 static int
-TohilExec_Cmd(ClientData clientData, /* Not used. */
-              Tcl_Interp *interp,    /* Current interpreter */
-              int objc,              /* Number of arguments */
-              Tcl_Obj *const objv[]  /* Argument strings */
-)
+TohilExec_Cmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     if (objc != 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "execString");
@@ -836,11 +820,7 @@ TohilExec_Cmd(ClientData clientData, /* Not used. */
 //   interpreter's interactive loop
 //
 static int
-TohilInteract_Cmd(ClientData clientData, /* Not used. */
-                  Tcl_Interp *interp,    /* Current interpreter */
-                  int objc,              /* Number of arguments */
-                  Tcl_Obj *const objv[]  /* Argument strings */
-)
+TohilInteract_Cmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     if (objc != 1) {
         Tcl_WrongNumArgs(interp, 1, objv, "");

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1332,7 +1332,7 @@ pyListToTclObjv(Tcl_Interp *interp, PyListObject *pList, int *intPtr, Tcl_Obj **
     // build up a tcl objv of the list elements
     Tcl_Obj **objv = (Tcl_Obj **)ckalloc(sizeof(Tcl_Obj *) * objc);
     for (i = 0; i < objc; i++) {
-        objv[i] = pyObjToTcl(tcl_interp, PyList_GET_ITEM(pList, i));
+        objv[i] = pyObjToTcl(interp, PyList_GET_ITEM(pList, i));
         Tcl_IncrRefCount(objv[i]);
     }
     *objvPtr = objv;

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -63,7 +63,6 @@ static int tohil_mod_exec(PyObject *m);
 
 typedef struct {
     Tcl_Interp *interp;
-    PyObject *error_class;
 } TohilModuleState;
 
 #define tohilstate(o) ((TohilModuleState *)PyModule_GetState(o))

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -100,7 +100,7 @@ tohil_TclObjToUTF8DString(Tcl_Interp *interp, Tcl_Obj *obj, Tcl_DString *ds)
 //
 // tohil_UTF8ToTclDString - convert a Python utf-8 string to a Tcl "WTF-8" string.
 // Use a DString for buffering.
-// 
+//
 static char *
 tohil_UTF8ToTclDString(Tcl_Interp *interp, char *utf8String, int utf8StringLen, Tcl_DString *ds)
 {
@@ -588,7 +588,8 @@ Tohil_ReturnExceptionToTcl(Tcl_Interp *interp, char *description)
     }
 
     if (!PyTuple_Check(pExceptionResult) || PyTuple_GET_SIZE(pExceptionResult) != 2) {
-        return Tohil_ReturnTclError(interp, "malfunction in tohil python exception handler, did not return tuple or tuple did not contain 2 elements");
+        return Tohil_ReturnTclError(interp,
+                                    "malfunction in tohil python exception handler, did not return tuple or tuple did not contain 2 elements");
     }
 
     Tcl_SetObjErrorCode(interp, pyObjToTcl(interp, PyTuple_GET_ITEM(pExceptionResult, 0)));
@@ -2249,7 +2250,7 @@ TohilTclDictIter_dealloc(Tohil_TD_IterObj *self)
 }
 
 static PyTypeObject Tohil_TD_IterType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil_td_iter",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil.td_iter",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD iterator type",
@@ -2260,7 +2261,7 @@ static PyTypeObject Tohil_TD_IterType = {
 };
 
 static PyTypeObject Tohil_TD_IterKeysType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil_td_keys",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil.td_keys",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD keys iterator object",
@@ -2271,7 +2272,7 @@ static PyTypeObject Tohil_TD_IterKeysType = {
 };
 
 static PyTypeObject Tohil_TD_IterValuesType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil_td_values",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil.td_values",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD values iterator object",
@@ -2282,7 +2283,7 @@ static PyTypeObject Tohil_TD_IterValuesType = {
 };
 
 static PyTypeObject Tohil_TD_IterItemsType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil_td_items",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "tohil.td_items",
     .tp_basicsize = sizeof(Tohil_TD_IterObj),
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil TD items iterator object",
@@ -3966,15 +3967,15 @@ static struct PyModuleDef_Slot tohil_slots[] = {
 // TODO: there should probably be some tcl deinit in the clear/free code
 static struct PyModuleDef TohilModule = {
     PyModuleDef_HEAD_INIT,
+    // this comment helps clang-format
     .m_name = "tohil",
-    .m_doc= "A module to permit interop with Tcl",
+    .m_doc = "A module to permit interop with Tcl",
     .m_size = sizeof(TohilModuleState),
     .m_methods = TohilMethods,
     .m_slots = tohil_slots,
 };
 
 /* Shared initialisation begins here */
-
 
 //
 // this is the entry point called when the tcl interpreter loads the tohil shared library
@@ -4197,7 +4198,7 @@ tohil_exec(PyObject *m)
 
     return 0;
 
-  fail:
+fail:
     Py_XDECREF(m);
     return -1;
 }

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -582,8 +582,7 @@ Tohil_ReturnExceptionToTcl(Tcl_Interp *interp, PyObject *m, char *description)
     }
 
     if (!PyTuple_Check(pExceptionResult) || PyTuple_GET_SIZE(pExceptionResult) != 2) {
-        return Tohil_ReturnTclError(interp,
-                                    m,
+        return Tohil_ReturnTclError(interp, m,
                                     "malfunction in tohil python exception handler, did not return tuple or tuple did not contain 2 elements");
     }
 

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -62,7 +62,7 @@ static PyObject *tohil_python_return(Tcl_Interp *, int tcl_result, PyTypeObject 
 static int tohil_exec(PyObject *m);
 
 typedef struct {
-    Tcl_Interp *tcl_interp;
+    Tcl_Interp *interp;
     PyObject *handle_exception_function;
     PyObject *error_class;
 } TohilModuleState;
@@ -4121,6 +4121,7 @@ tohil_exec(PyObject *m)
         Py_DECREF(pCap);
     }
     tcl_interp = interp;
+    tohilstate(m)->interp = interp;
 
     // set the near-standard dunder version for our module (tohil._tohil)
     // to the package version passed to the compiler command line by
@@ -4166,6 +4167,7 @@ tohil_exec(PyObject *m)
     // our returns are a little different, but this is a candidate for
     // some kind of simplifying subroutine.
     pTohilHandleException = PyObject_GetAttrString(pTohilMod, "handle_exception");
+    tohilstate(m)->handle_exception_function = pTohilHandleException;
     if (pTohilHandleException == NULL || !PyCallable_Check(pTohilHandleException)) {
         Py_XDECREF(pTohilHandleException);
         Py_DECREF(pTohilMod);
@@ -4173,6 +4175,7 @@ tohil_exec(PyObject *m)
     }
 
     pTohilTclErrorClass = PyObject_GetAttrString(pTohilMod, "TclError");
+    tohilstate(m)->error_class = pTohilTclErrorClass;
     if (pTohilTclErrorClass == NULL || !PyCallable_Check(pTohilTclErrorClass)) {
         Py_XDECREF(pTohilTclErrorClass);
         Py_DECREF(pTohilMod);


### PR DESCRIPTION
Prior to this PR, tohil used single-phase init and had some global pointers that it maintained.  This prevented tohil from being used in subinterpreters.

This PR switches tohil to use multi-phase init and to get rid of all the globals.

As a result, tohil should now work within subinterpreters.