### PR TITLE
return tclobjs by default; python subinterpreter handling improvements; much improved docs; version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+.hypothesis
 
 # Intermediate build files
 tohil.o

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -14,6 +14,9 @@ help:
 
 .PHONY: help Makefile
 
+serve:
+	cd _build/html && python3 -m http.server
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/Doc/reference/index.rst
+++ b/Doc/reference/index.rst
@@ -16,5 +16,5 @@ describes the library that is Tohil.
    intro.rst
    tohil_types.rst
    tohil_exceptions.rst
-   tohil_tcl-errors.rst
+   tohil_tcl_errors.rst
 

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -17,7 +17,7 @@
       <p class="biglink"><a class="biglink" href="{{ pathto("reference/index") }}">{% trans %}Tohil Reference{% endtrans %}</a><br/>
     </td><td width="50%">
       <p class="biglink"><a class="biglink" href="{{ pathto("installing/index") }}">{% trans %}Building and Installing Tohil{% endtrans %}</a><br/>
-         <span class="linkdescr">{% trans %}Building Tohil on Unix-like systems{% endtrans %}</span></p>
+         <span class="linkdescr">{% trans %}Building Tohil on Unix systems such as Linux, MacOS and FreeBSD{% endtrans %}</span></p>
     </td></tr>
   </table>
 

--- a/Doc/tutorial/intro.rst
+++ b/Doc/tutorial/intro.rst
@@ -1,0 +1,40 @@
+.. _tutorial-index:
+
+######################
+  The Tohil Tutorial
+######################
+
+Tohil is simultaneously a Python extension and a TCL extension that
+makes it really seamless to move data around and invoke functions in
+one from the other.
+
+Tohil is open source software, available for free including for profit and/or for redistribution, under the permissive 3-clause BSD license (See :ref:`_copyright-and-license`).
+
+It is written in C, Python and Tcl, and makes use of the Python and Tcl C APIs
+to let Python call Tcl, Tcl call Python, give Python access to Tcl's
+objects and give Tcl access to Python's objects.
+
+Not just strings and ints and float, but lists, dicts, sets, tuples, and
+more, flow freely, intuitively and largely unencumbered between the two
+languages.
+
+Tohil is efficient when moving data between the languages.
+Integers and floats are copied natively; they do not suffer an
+intermediate conversion through strings.  Likewise lists, tuples, dicts,
+etc, are accessed through the C language mechanisms provided by the two
+languages, ergo accessed and manipulated in the most native and efficient
+ways.
+
+Tohil is freely available
+in source form from the Tohil github website,
+https://github.com/flightaware/tohil, and may be freely distributed.
+
+This tutorial is intended to provide an introduction to Tohil, and
+typical ways of using it.
+
+To follow along and start experimenting with Tohil you'll want to have  working Python
+and Tcl interpreters, and have
+Tohil built and installed such that `import tohil` works from
+Python and `package require tohil` works from Tcl.
+
+

--- a/Doc/tutorial/intro.rst
+++ b/Doc/tutorial/intro.rst
@@ -1,4 +1,4 @@
-.. _tutorial-index:
+.. _tutorial-intro:
 
 ######################
   The Tohil Tutorial

--- a/Doc/tutorial/tohil_python.rst
+++ b/Doc/tutorial/tohil_python.rst
@@ -1,0 +1,8 @@
+
+
+
+
+>>> import tohil
+>>> clock = 1616182348
+>>> tohil.eval(f"clock format {clock} -locale es -gmt 1")
+'vie mar 19 19:32:28 GMT 2021'

--- a/Doc/tutorial/tohil_python.rst
+++ b/Doc/tutorial/tohil_python.rst
@@ -4,9 +4,297 @@
 Using Tcl from Python
 ======================
 
+Here we'll introduce using Tcl from Python.
+
+Hopefully you've got Tcl and Python and Tohil installed and you can
+follow along and try stuff out.
+
+**************
+tohil.eval
+**************
+
+::
+
+   >>> import tohil
+   >>> tohil.eval('puts "Hello, world."')
+   Hello, world.
+
+Not bad.  You can actually do a lot with that.
+
+Anything the Tcl code returns can be gotten by Python.
+
+::
+
+   >>> t = tohil.eval('return "Hello, world."')
+   >>> t
+   <tohil.tclobj: 'Hello, world.'>
+   >>> str(t)
+   'Hello, world.'
+
+Here we'll use Tcl's *clock format* function to format a
+Unix epoch seconds-since-1970 clock into a Posix standard
+time in the Spanish locale:
+
+::
+
+   >>> clock = 1616182348
+   >>> tohil.eval(f"clock format {clock} -locale es -gmt 1")
+   'vie mar 19 19:32:28 GMT 2021'
+
+*****************
+helper functions
+*****************
+
+We can load in Tcl packages by doing
+
+::
+
+   >>> tohil.eval('package require Tclx')
+
+but we do this so often that tohil provides a shortcut:
+
+::
+
+   >>> tohil.package_require('Tclx')
+
+You can specify the verison as an optional argument, either by
+positional or named parameter.  The following two statements
+are equivalent:
+
+::
+
+   >>> tohil.package_require('Tclx', '8.6')
+   >>> tohil.package_require('Tclx',version='8.6')
+
+Experienced Python users without a lot of Tcl experience may be surprised
+by Tcl's leniency when it comes to data types.
+
+Here we request a Tcl package with the version number specified as
+floating point.  It works fine.
+
+::
+
+   >>> tohil.package_require('Tclx', 8.6)
+
+Another one you'd end up doing a lot is ``tohil.eval("source file.tcl")``.  For that
+we provide the slightly less paper-cutty ``tohil.source("file.tcl")``.
+
+
+**************
+tohil.call
+**************
+
+You get fancy and start using f-strings to create Tcl commands with
+arguments, maybe you're doing something like
+
+::
+
+   tohil.eval(f"register_user {user_id} {user_name} {user_fullname}")
+
+If any of those variables being substituted contain dollar signs,
+quotes, or square brackets, you're not going to have a good time,
+because Tcl is going to try to interpret that stuff, and that could
+lead to errors up to and including remote code execution.
+
+Consequently, Tohil provides *tohil.call*, a function that takes an
+arbitrary number of arguments and passes them one-for-one to the
+corresponding Tcl function in a way that keeps Tcl from trying
+to interpret any of the arguments.
+
 ::
 
    >>> import tohil
    >>> clock = 1616182348
-   >>> tohil.eval(f"clock format {clock} -locale es -gmt 1")
-   'vie mar 19 19:32:28 GMT 2021'
+   >>> tohil.call('clock', 'format', clock, '-locale', 'fr')
+   'ven. mars 19 19:32:28 UTC 2021'
+
+The key thing in the above is
+``tohil.call('clock', 'format', clock, '-locale', 'fr')``, equivalent
+to ``tohil.eval(f"clock format {clock} -locale fr")`` but without the
+risk of inadvertent misinterpretation of arguments.
+
+
+**************
+tohil.expr
+**************
+
+You can also evaluate Tcl expressions from Python using *tohil.expr*.
+As with many other tohil functions, to= can be used to request conversion to a
+specific Python datatype.
+
+::
+
+
+   >>> tohil.expr('5+5')
+   '10'
+   >>> tohil.expr('5**5')
+   '3125'
+   >>> tohil.expr('1/3')
+   '0'
+   >>> tohil.expr('1/3.')
+   '0.3333333333333333
+   >>> tohil.expr('1/3.',to=float)
+   0.3333333333333333
+   >>> tohil.expr('[clock seconds] % 86400')
+   '25571'
+   >>> tohil.expr('[clock seconds] % 86400',to=int)
+   25571
+
+******************************
+tohil.getvar and tohil.setvar
+******************************
+
+Python has direct access to Tcl variables and arrays using *tohil.getvar*.
+Likewise, *tohil.setvar* can set them.
+
+::
+
+   >>> import tohil
+   >>> tohil.setvar("foo", "bar")
+   >>> tohil.getvar("foo")
+   'bar'
+   >>> tohil.setvar(var="happy", value="lamp")
+   >>> tohil.getvar("happy")
+   'lamp'
+
+   >>> tohil.eval("array set x [list a 1 b 2 c 3 d 4]")
+   ''
+   >>> tohil.getvar('x(a)')
+   '1'
+   >>> tohil.getvar('x(a)', to=int)
+   1
+   >>> tohil.getvar(var='x(b)', to=float)
+   2.0
+   >>> tohil.getvar("x(e)")
+   Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+   RuntimeError: can't read "x(e)": no such element in array
+
+As you can see, it's an error to try to get a variable or array element
+that isn't there.  You can use tohil.exists to see if the variable is there,
+or trap the Python exception, or make use of *tohil.getvar*'s handy
+*default* keyword-only argument.
+
+::
+
+   >>> tohil.getvar("x(e)", default="0")
+   '0'
+   >>> tohil.getvar("x(e)", default=0, to=int)
+   0
+   >>> tohil.getvar("x(d)", default=0, to=int)
+   4
+
+****************
+tohil.exists
+****************
+
+Since it is an error to try to *tohil.getvar* a variable that doesn't exist,
+you can trap the request from Python and handle the exception,
+or use *tohil.exists* to see if the var or array element exist.
+
+::
+
+   >>> tohil.eval("array set x [list a 1 b 2 c 3 d 4]")
+   ''
+   >>> tohil.exists("x(c)")
+   True
+   >>> tohil.exists("x(e)")
+   False
+   >>>
+   >>> tohil.exists("banana")
+   False
+
+
+***************
+tohil.incr
+***************
+
+*tohil.incr* takes a Tcl variable name or array element and attempts
+to increment it.
+
+If the contents of the variable preclude it being used as an int, a Python
+TypeError exception is thrown.
+
+An optional position argument specifies an increment amount.  The default
+increment is 1.
+Negative increments are permitted.
+The increment amount can also be specified as
+a keyword argument, using "incr".
+
+::
+
+   tohil.incr('var')
+   tohil.incr('var',2)
+   tohil.incr('var',incr=-1)
+
+
+**************
+tohil.unset
+**************
+
+*tohil.unset* can be used to unset variables, array elements, and even entire
+arrays in the Tcl interpreter.
+
+::
+
+   >>> tohil.setvar("x(e)", "5")
+   >>> tohil.getvar("x(e)")
+   '5'
+   >>> tohil.unset("x(e)")
+   >>> tohil.getvar("x(e)")
+   Traceback (most recent call last):
+     File "<stdin>", line 1, in <module>
+   RuntimeError: can't read "x(e)": no such element in array
+
+* Unset takes an arbitrary number of arguments, including zero.
+* Unsetting an array element uses Tcl subscript notation, for example
+  ``tohil.unset('x(e)')``.
+* Unsetting an array by name without a subscript will unset the entire array.
+* It is not an error to attempt to unset a variable that doesn't exist.
+
+******************
+tohil.subst
+******************
+
+Tcl's *subst* command is pretty cool.  By default it performs Tcl backslash,
+command and variable substitutions, but doesn't evaluate the final result,
+like *eval* would.  So it's handy for generating some kind of string, but
+with embedded $-substitution and square bracket evaluation.
+
+::
+
+   >>> import tohil
+   >>> tohil.eval("set name karl")
+   'karl'
+   >>> tohil.subst("hello, $name")
+   'hello, karl'
+
+*******************
+tohil.convert
+*******************
+
+*tohil.convert* will convert some Python thing passed to it, into a Tcl
+object, and then back to some other Python type,
+any type supported in accordance with the to= argument.
+
+
+The "to=" way of requesting a type conversion is supported.  Although you might not care about converting to int or float or something, you might want a tohil.tclobj for your efforts, anirite?
+
+*******************
+tohil.interact
+*******************
+
+Run the Tcl interactive command loop on stdin, hopefully a terminal, until
+you send an EOF, at which point you'll be returned to the Python command
+line.  See also *tohil::interact*.
+
+THis is handy if you're using Python interactively and you find yourself
+making a lot of *tohil.eval* calls to manipulate the Tcl interpreter, you
+can flip to the Tcl interpreter, interact with it directly, then flip
+back by sending an end-of-file.
+
+
+
+tcldict
+tclobj
+tclvar

--- a/Doc/tutorial/tohil_python.rst
+++ b/Doc/tutorial/tohil_python.rst
@@ -298,3 +298,5 @@ back by sending an end-of-file.
 tcldict
 tclobj
 tclvar
+=======
+>>>>>>> e7333ccf4bcd0c70073e5b93170683cd3d9560f6

--- a/Doc/tutorial/tohil_python.rst
+++ b/Doc/tutorial/tohil_python.rst
@@ -1,8 +1,12 @@
+.. _tutorial-tcl-from-python:
 
+======================
+Using Tcl from Python
+======================
 
+::
 
-
->>> import tohil
->>> clock = 1616182348
->>> tohil.eval(f"clock format {clock} -locale es -gmt 1")
-'vie mar 19 19:32:28 GMT 2021'
+   >>> import tohil
+   >>> clock = 1616182348
+   >>> tohil.eval(f"clock format {clock} -locale es -gmt 1")
+   'vie mar 19 19:32:28 GMT 2021'

--- a/Doc/tutorial/tohil_tcl.rst
+++ b/Doc/tutorial/tohil_tcl.rst
@@ -1,4 +1,8 @@
+.. _tutorial-python-from-tcl:
 
+======================
+Using Python From Tcl
+======================
 
 In this section we'll introduce using Python from Tcl.
 
@@ -17,7 +21,9 @@ If the package-require failed then please visit
 the installation instructions and get tohil built and installed
 on your computer.
 
+***************
 tohil::eval
+***************
 
 ::
 
@@ -34,7 +40,9 @@ and returned the result back to tcl.
   % puts $answer
   42
 
-tohil::eval
+***************
+tohil::exec
+***************
 
 In Python, *eval* evaluates a single expression and returns the
 result, so even trying to eval something like ``answer = 42`` is
@@ -74,7 +82,9 @@ two integers yielded an integer result while Python, a float?  Then
 we used Python's integer division *//* to get integer division, while
 trying that with Tcl was an error because Tcl doesn't have that operator.
 
+***************
 tohil::import
+***************
 
 OK, we can start doing Python stuff from Tcl, like import a module.
 
@@ -89,7 +99,9 @@ We do this often enough that Tohil provides a shortcut:
    % tohil::import numpy
 
 
+****************
 notes about exec
+****************
 
 One thing that can trip people up is it can be surprising that
 tohil::exec never returns anything.
@@ -110,13 +122,17 @@ be a surprise that Tohil is using Python's
 eval and exec mechanisms at the C level to provide these capabilities
 to Tcl.
 
+***************
 tohil::run
+***************
 
 tohil::run is a special version of tohil::exec that grabs anything
 Python emits to stdout while the exec is running, and returns it
 to the caller.
 
+***************
 tohil::call
+***************
 
 If you start creating from Tcl, Python to be executed with
 eval and exec, you may notice there's a risk that if you use
@@ -139,7 +155,9 @@ tohil::import provides a way to import Python modules, although it's not much
 different from doing a tohil::exec "import module"
 
 
-#### tohil::interact
+***************
+tohil::interact
+***************
 
 Take tohil to eleven.  You're on ten here... all the way up... You're
 on ten on your guitar... where can you go from there?  Where?  Nowhere.
@@ -161,8 +179,9 @@ return to the Tcl one.
     bar
 
 
-
+**********************
 Using tohil from Rivet
+**********************
 
 Rivet is an Apache webserver module that provides among other things
 a way for webpages to be made from HTML files with embedded Tcl code

--- a/Doc/tutorial/tohil_tcl.rst
+++ b/Doc/tutorial/tohil_tcl.rst
@@ -1,0 +1,192 @@
+
+
+In this section we'll introduce using Python from Tcl.
+
+Hopefully you've got Tcl and Python and Tohil installed and you can
+follow along and try stuff out.
+
+Let's fire up Tcl and mess around with Python::
+
+   $ tclsh
+   % package require tohil
+   4.0.0
+
+OK, good news, we've got a working Tcl and Tohil.
+
+If the package-require failed then please visit
+the installation instructions and get tohil built and installed
+on your computer.
+
+tohil::eval
+
+::
+
+   % tohil::eval "37 + 5"
+   42
+
+That may not look like much, but Tohil got Python to add 37 and 5 for us
+and returned the result back to tcl.
+
+::
+
+  % set answer [tohil::eval "37 + 5"]
+  42
+  % puts $answer
+  42
+
+tohil::eval
+
+In Python, *eval* evaluates a single expression and returns the
+result, so even trying to eval something like ``answer = 42`` is
+an error.  Python provides *exec*, which can evaluate an aribtrary
+code block, and Tohil hews to that by providing *tohil::exec*.
+
+::
+
+   % tohil::exec "answer = 37 + 5"
+   % tohil::exec "print(answer)"
+   42
+
+OK, that's pretty cool.  Tohil is getting Python to do stuff
+for us from Tcl.  Yay.
+
+(A quick note, *tohil::eval* and *tohil::exec* are named and work the
+way Python's *eval* and *exec* work.  Tcl has its own *eval* for
+evaluating Tcl stuff. It is for Tcl something closer to Python's *exec*,
+except that Tcl's *eval* returns a result, while Tcl's *exec* runs programs
+and returns their output, something much different.)
+
+::
+
+   % expr 5 / 4
+   1
+   % tohil::eval "5 / 4"
+   1.25
+   % tohil::eval "5 // 4"
+   1
+   % expr 5 // 4
+   missing operand at _@_
+   in expression "5 /_@_/ 4"
+   while evaluating expr 5 // 4
+
+Yep, it's Python we're talking to, all right.  See how Tcl division of
+two integers yielded an integer result while Python, a float?  Then
+we used Python's integer division *//* to get integer division, while
+trying that with Tcl was an error because Tcl doesn't have that operator.
+
+tohil::import
+
+OK, we can start doing Python stuff from Tcl, like import a module.
+
+::
+
+   % tohil::exec "import numpy"
+
+We do this often enough that Tohil provides a shortcut:
+
+::
+
+   % tohil::import numpy
+
+
+notes about exec
+
+One thing that can trip people up is it can be surprising that
+tohil::exec never returns anything.
+
+::
+
+   % tohil::exec "answer = 42"
+   % tohil::exec "answer"
+
+The above returns without an error, but doesn't provide anything.
+
+You instead need to use tohil::eval in this example.  You can call
+functions using tohil::eval, by the way.
+
+Though possibly a bit surprising, this behavior is consistent
+with how exec works in Python. It probably sbhouldn't
+be a surprise that Tohil is using Python's
+eval and exec mechanisms at the C level to provide these capabilities
+to Tcl.
+
+tohil::run
+
+tohil::run is a special version of tohil::exec that grabs anything
+Python emits to stdout while the exec is running, and returns it
+to the caller.
+
+tohil::call
+
+If you start creating from Tcl, Python to be executed with
+eval and exec, you may notice there's a risk that if you use
+substitute-in data, you know, such as names, addresses, cities
+or whatever, that unless you are very careful, various characters
+can cause your Python not to parse properly.  For example, a single
+quote in a name, quotes in general, and other stuff.
+
+Tohil provides *tohil::call* to make it possible to call a Python
+function and make sure that the arguments you pass to the function
+are not interpreted by Python along the way.
+
+
+tohil::call provides a way to invoke one Python function, with zero or more
+arguments, without having to pass it through Python's eval or exec and running
+the risk that Python metacharacters appearing in the data will cause quoting
+problems, accidental code execution, etc.
+
+tohil::import provides a way to import Python modules, although it's not much
+different from doing a tohil::exec "import module"
+
+
+#### tohil::interact
+
+Take tohil to eleven.  You're on ten here... all the way up... You're
+on ten on your guitar... where can you go from there?  Where?  Nowhere.
+Exactly.  What we do is if we need that extra... push over the cliff...
+you know what we do?
+
+We run *tohil::interact* from Tcl and enter the Python interactive loop.
+When we're done, we send end of file (^D) to end the Python loop and
+return to the Tcl one.
+
+::
+
+   % tohil::interact
+   >>> def foo():
+   ...   print("bar")
+   ...
+   >>> ^D
+   % tohil::eval foo()
+    bar
+
+
+
+Using tohil from Rivet
+
+Rivet is an Apache webserver module that provides among other things
+a way for webpages to be made from HTML files with embedded Tcl code
+that executes when the page is requested.
+
+From a Rivet page, in some of your Tcl code, invoke `package require tohil`.
+
+If you run tohil_rivet it will plug tohil's Python interpreter such that
+everything Python writes to stdout using print, or whatever, will go through
+Tcl's stdout and thereby into your Rivet page.
+
+::
+
+   <?
+
+   package require tohil; tohil_rivet
+
+   puts "calling out to Python to add 5 + 5: [::tohil::eval "5 + 5"]"
+
+   tohil::exec {
+       print('hello, world')
+       print("<hr>")
+   }
+
+   ?>
+
+

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -5,7 +5,9 @@
   What's New In Tohil 3.2
 ****************************
 
-### tclobjs
+========
+tclobjs
+========
 
 Tohil Tcl objects, tclobjs, are a data type Tohil creates in Python.
 Tclobjs have gained considerable new power.  Among them, they now
@@ -52,14 +54,18 @@ renamed to *extend*, for compatibility with Python's lists.
 * tclobjs can now ingest python sets (in addition to lists, tuples, etc,
   which it already could do.)
 
-### Tclobj Shadow Vars
+======================
+Tclobj Shadow Vars
+======================
 
 Another new feature, Tclobj shadow vars, `t = tohil.tclvar('t')`, makes *t* a
 tclobj that shadows a variable *t* in the Tcl interpreter.  Any changes to the
 variable from the Tcl side are "seen" from the Python side, and vice versa.
 The variable can also be an array element.
 
-### Tcldicts
+======================
+Tcldicts
+======================
 
 * Tcldict objects now provide many methods that standard Python dicts
   provide, such as keys(), values(), items().  Because of this,
@@ -73,7 +79,9 @@ The variable can also be an array element.
 
 * A new *.insert(i, x)* method will insert item x at position i.
 
-### ShadowDicts
+======================
+ShadowDicts
+======================
 
 ShadowDicts implement many additional methods implemented by standard
 Python dicts.
@@ -82,18 +90,24 @@ ShadowDicts now have a *get* method that behaves as standard dicts do.
 A new *clear* method removes all items from the shadow diction, i.e. it
 unsets the shadowed Tcl array.
 
-### Python exception improvements
+=============================
+Python exception improvements
+=============================
 
 We now raise more standard Python TypeError, KeyError and ValueError exceptions
 in places where we used to just raise RuntimeError.
 
-### Tohil method improvements and changes
+======================================
+Tohil method improvements and changes
+======================================
 
 Tohil.unset can now take an arbitrary number of arguments of variable names
 and array elements to unset, include zero.  As before, it is fine to unset
 something that doesn't exist.
 
-### Testing Improvements
+======================================
+Testing Improvements
+======================================
 
 * Lots of new tests.
 * Also we're now using the hypothesis testing framework and have found
@@ -101,8 +115,8 @@ something that doesn't exist.
 * All tests pass now on 32-bit ARM Linux.
 * Linux CI automated testing using Github Actions
 
-### Build Improvements
-
-* 
+======================================
+Build Improvements
+======================================
 
 

--- a/Doc/whatsnew/4.0.rst
+++ b/Doc/whatsnew/4.0.rst
@@ -102,7 +102,7 @@ A function can now be specified in a to= arg
 =============================================
 
 The *to=* argument to a Tohil function such as *tohil.eval*,
-*tohil.call*, etc, has until been required to be a support
+*tohil.call*, etc, has until now been required to specify a
 Python data type such as *int*, *float*, *str*, *tohil.tclobj*,
 etc, it can now also be specified as a callable function.
 
@@ -131,7 +131,6 @@ Internal Changes
   we use ``PyInitializeEx(0)`` instead of ``Py_Initialize`` to
   prevent Python from registering signal handlers.  (Signal handling probably
   ought to be Tcl's business under this circumstance.)
-
 
 * Internal code refactoring and cleanup.
 

--- a/Doc/whatsnew/4.0.rst
+++ b/Doc/whatsnew/4.0.rst
@@ -1,0 +1,77 @@
+
+.. 4.0.rst:
+
+****************************
+  What's New In Tohil 4.0
+****************************
+
+==================================
+Python Subinterpreter Support
+==================================
+
+Full Python subinterpreter support!
+
+First, starting with version 4, Tohil properly supports multi-phase init,
+meaning that multiple Python interpreters (the Python interpreter and
+any subinterpreters) can import tohil and they will get their own instance
+of Tohil, so there is no "crosstalk" between the interpreters.
+
+Second, Tohil recognizes when a second Tcl interpreter within the same
+process has done a ``package require tohil`` and will create and exclusively
+interact with a separate, distinct Python subinterpreter for each
+corresponding Tcl interpreter.
+
+Say for instance you create a new Tcl interpreter from Tcl, using
+something like ``set interp [interp create]`` and then do
+``$interp eval "package require tohil"``, that second interpreter
+doing the package require causes a new Python subinterpreter to be
+created and initialized.
+
+And it works great.
+
+When any of the Tcl interpreters exercises their Python interpreter,
+Tohil will automatically switch Python's executing interpreter to
+that interpreter (swap its thread state), if needed.
+
+This was pretty tricky, because we previously had global variables,
+in particular one pointing to the Tcl interpreter.  We had to figure
+out ways to stash the pointer to the Tcl interpreter in Python using
+C such that we could find it later when we didn't have control over
+how we were called, for example we are being called from Python with
+to do some Python thing, you only get what it calls you with.  So we
+stashed the interpreter pointer in a capsule in Tohil's Python data types'
+dictionaries and in __main__'s dictionary.  It turned out really nice.
+
+==================================================
+Support for Separate Virtual Interpreters in Rivet
+==================================================
+
+A nice bit of fallout from the above, if you're running the Apache
+webserver with the
+Apache Rivet module installed and running in the mode where different
+virtual hosts run in separate Tcl interpreters, known as separate virtual
+interpreters, each vhost that does a ``package require tohil`` will get its
+own Python subinterpreter, isolating Python between the vhosts just as
+Tcl is.
+
+=========================
+Additional Improvements
+=========================
+
+* When Tcl is the parent and Tohil initializes Python from scratch,
+  we use ``PyInitializeEx(0)`` instead of ``Py_Initialize`` to
+  prevent Python from registering signal handlers.  (That seems like
+  Tcl's business under this circumstance.)
+* When Tcl is the parent, ``package require tohil`` will, in addition to
+  initializing Python, automatically import tohil on the Python side.
+
+
+* Internal code refactoring and cleanup.
+
+================================
+Documentation Improvements
+================================
+
+* Greatly improved documentation in Python-standard format.
+* Makefile and docs for building the docs.
+

--- a/Doc/whatsnew/4.0.rst
+++ b/Doc/whatsnew/4.0.rst
@@ -5,6 +5,44 @@
   What's New In Tohil 4.0
 ****************************
 
+==========================
+tclobj default return
+==========================
+
+This is a biggie.  Many Tohil functions accept a *to=* argument
+where you can specify a Python data type to convert the return
+of the call to.  In the past, and going forward, you could
+set a return type of *str*, *int*, *bool*, *float*, *list*, *set*,
+*dict*, *tuple*, *tohil.tclobj* or *tohil.tcldict*.
+
+Prior to Tohil 4, if you didn't set a *to=* return type, the default
+return type was string, *str*.  This seemed perfectly reasonable.
+After all, in Tcl, despite it having internal objects and maintaining
+in them a cache of a conversion to a data type such as integer, list,
+etc, everything is a string.
+
+However, as we have enhanced and extended our tclobj type, it has become
+easier and easier to use it from Python with no funny business.
+You can get a tclobj's string representation with *str()*, integer
+with *int()*, float with *float()*, list with *list()*, and others.
+You can use Python list notation to access and manipulate elements
+of tclobjs when they contain lists, can iterate over them, etc.
+
+Since our tclobj type implements Python's number protocol, if tclobjs
+contain numbers, they can be used in calculations without
+any conversion required.
+
+Consequently starting in Tohil 4, the default *to* return is now
+*tohil.tclobj*.  In our experience, and a little bit to our surprise,
+most Python code that uses Tohil will "just work", without modifications.
+
+If, though, for instance, you didn't specify a default return and then
+knowing you would get a str invoked string methods on the str, you'll
+get an error if the tclobj doesn't implement those methods.  In this
+case, adding a *to=str* to the Tohil call will be sufficient to get
+your code working under Tohil 4.
+
+
 ==================================
 Python Subinterpreter Support
 ==================================
@@ -33,7 +71,11 @@ When any of the Tcl interpreters exercises their Python interpreter,
 Tohil will automatically switch Python's executing interpreter to
 that interpreter (swap its thread state), if needed.
 
-This was pretty tricky, because we previously had global variables,
+Upon deletion of a Tcl interpreter, if there is an attached
+Python subinterpreter, it is deleted as well.
+
+Implementation Note:  This was pretty tricky, because we previously
+had global variables,
 in particular one pointing to the Tcl interpreter.  We had to figure
 out ways to stash the pointer to the Tcl interpreter in Python using
 C such that we could find it later when we didn't have control over
@@ -54,6 +96,25 @@ virtual hosts run in separate Tcl interpreters, known as separate virtual
 interpreters, each vhost that does a ``package require tohil`` will get its
 own Python subinterpreter, isolating Python between the vhosts just as
 Tcl is.
+
+=============================================
+A function can now be specified in a to= arg
+=============================================
+
+The *to=* argument to a Tohil function such as *tohil.eval*,
+*tohil.call*, etc, has until been required to be a support
+Python data type such as *int*, *float*, *str*, *tohil.tclobj*,
+etc, it can now also be specified as a callable function.
+
+If the *to* argument is a callable function, Tohil will call it
+with one argument, a tclobj object containing the object
+to be returned, and it is up to the function to manipulate the
+object in some way.  Whatever the function returns is what the
+relevant tohil function will return.
+
+This provides an additional way for a Tohil developer to customize
+the return of some Tcl activity in order to make it more standard
+and readily useful to the Python caller.
 
 ============================
 User-Facing Behavior Changes

--- a/Doc/whatsnew/4.0.rst
+++ b/Doc/whatsnew/4.0.rst
@@ -48,22 +48,28 @@ Support for Separate Virtual Interpreters in Rivet
 
 A nice bit of fallout from the above, if you're running the Apache
 webserver with the
-Apache Rivet module installed and running in the mode where different
+`Apache Rivet https://tcl.apache.org/rivet/`_ module installed and running
+in the mode where different
 virtual hosts run in separate Tcl interpreters, known as separate virtual
 interpreters, each vhost that does a ``package require tohil`` will get its
 own Python subinterpreter, isolating Python between the vhosts just as
 Tcl is.
 
+============================
+User-Facing Behavior Changes
+============================
+
+* When Tcl is the parent, ``package require tohil`` will, in addition to
+  initializing Python, automatically import tohil on the Python side.
+
 =========================
-Additional Improvements
+Internal Changes
 =========================
 
 * When Tcl is the parent and Tohil initializes Python from scratch,
   we use ``PyInitializeEx(0)`` instead of ``Py_Initialize`` to
-  prevent Python from registering signal handlers.  (That seems like
-  Tcl's business under this circumstance.)
-* When Tcl is the parent, ``package require tohil`` will, in addition to
-  initializing Python, automatically import tohil on the Python side.
+  prevent Python from registering signal handlers.  (Signal handling probably
+  ought to be Tcl's business under this circumstance.)
 
 
 * Internal code refactoring and cleanup.
@@ -74,4 +80,4 @@ Documentation Improvements
 
 * Greatly improved documentation in Python-standard format.
 * Makefile and docs for building the docs.
-
+* ``make serve`` target to serve the docs via http (for devs)

--- a/Doc/whatsnew/index.rst
+++ b/Doc/whatsnew/index.rst
@@ -10,6 +10,7 @@
 .. toctree::
    :maxdepth: 2
 
+   4.0.rst
    3.2.rst
    3.0.rst
 

--- a/KNOTES.md
+++ b/KNOTES.md
@@ -378,4 +378,20 @@ so you need a mechanism to spot that second tcl interpreter
 
 you'd need to store it somewhere reliable but not off of a global
 
+ok, this led to an acceptable answer.  when python is the parent,
+it sets the tcl interpreter that it creates, it sets its python interpreter
+using the set assoc data thing in tcl to be the associated python
+interpreter to this tcl interpreter.
+
+if tcl is the parent and the python interpreter hasn't already been
+initialized, tohil initializes it and sets the main python interpreter
+using the set assoc data thing.
+
+if tcl is the parent and the python interpreter has already been initialized
+and the current tcl interpreter doesn't have a python interpreter set,
+tohil uses Py_NewInterpreter() to create a ne3w interpreter and associate
+it with the current tcl interpreter.
+
+-----
+
 

--- a/README.Linux
+++ b/README.Linux
@@ -1,9 +1,17 @@
 
-
+#
+# install python3 dev and python3 pip installer, then
+# use pip to install the hypothesis testing framework,
+# which tohil needs for its tests:
+#
 # sudo apt install python3-dev python3-pip
 # sudo pip3 install hypothesis
+#
+# say you build your own python in /opt/local...
+# ./configure --prefix=/opt/local --with-python-version=3.9
+#
 
 autoreconf
 ./configure --with-python-version=3.7m
 
-# don't forget the "m"
+# don't forget the "m" if your stuff has that, which debian tends to.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so that we create the export library with the dll.
 #-----------------------------------------------------------------------
 
-AC_INIT([tohil],[3.2.0])
+AC_INIT([tohil],[4.0.0])
 
 #--------------------------------------------------------------------
 # Call TEA_INIT as the first TEA_ macro to set up initial vars.

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -3678,7 +3678,11 @@ tohil_python_return(Tcl_Interp *interp, int tcl_result, PyObject *toType, Tcl_Ob
     }
     // printf("tohil_python_return called: tcl result %d, to=%s, resulObj '%s'\n", tcl_result, toString, Tcl_GetString(resultObj));
 
-    if (toType == NULL || STREQU(toString, "str")) {
+    if (toType == NULL || STREQU(toString, "tohil.tclobj")) {
+        return TohilTclObj_FromTclObj(interp, resultObj);
+    }
+
+    if (STREQU(toString, "str")) {
         int tclStringSize;
         char *tclString;
         int utf8len;
@@ -3724,10 +3728,6 @@ tohil_python_return(Tcl_Interp *interp, int tcl_result, PyObject *toType, Tcl_Ob
         }
         PyErr_SetString(PyExc_ValueError, Tcl_GetString(Tcl_GetObjResult(interp)));
         return NULL;
-    }
-
-    if (STREQU(toString, "tohil.tclobj")) {
-        return TohilTclObj_FromTclObj(interp, resultObj);
     }
 
     if (STREQU(toString, "tohil.tcldict")) {

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -3678,6 +3678,14 @@ tohil_python_return(Tcl_Interp *interp, int tcl_result, PyObject *toType, Tcl_Ob
     }
     // printf("tohil_python_return called: tcl result %d, to=%s, resulObj '%s'\n", tcl_result, toString, Tcl_GetString(resultObj));
 
+    // if there's no "to" specified and the result object is empty,
+    // just return None.  This is experimental.  Not sure about it.
+    if (0 && toType == NULL) {
+        if (resultObj->bytes != NULL && resultObj->length == 0) {
+            Py_RETURN_NONE;
+        }
+    }
+
     if (toType == NULL || STREQU(toString, "tohil.tclobj")) {
         return TohilTclObj_FromTclObj(interp, resultObj);
     }

--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -201,9 +201,9 @@ def source(file_name, encoding=""):
 def package_require(package, version=""):
     """try to load the specified package."""
     if version == "":
-        return _tohil.call("package", "require", package)
+        return _tohil.call("package", "require", package, to=str)
     else:
-        return _tohil.call("package", "require", package, version)
+        return _tohil.call("package", "require", package, version, to=str)
 
 
 def use_vhost(vhost=""):

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -2,6 +2,11 @@ import unittest
 
 import tohil
 
+def filter_minus_1(val):
+    return val - 1
+
+def filter_too_many_args(val1, val2):
+    return val1 + 1
 
 class TestEval(unittest.TestCase):
     def test_eval1(self):
@@ -48,6 +53,20 @@ class TestEval(unittest.TestCase):
         """exercise tohil.eval and to=someting_wrong"""
         with self.assertRaises(NameError):
             tohil.eval("list 1 2 3", to=no_such_type)
+
+    def test_eval8(self):
+        """exercise tohil.eval and to=function"""
+        self.assertEqual(tohil.eval("return 10", to=filter_minus_1), 9)
+
+    def test_eval9(self):
+        """exercise tohil.eval and an incorrect to=function"""
+        with self.assertRaises(TypeError):
+            tohil.eval("list 1 2 3", to=filter_too_many_args)
+
+    def test_eval10(self):
+        """exercise tohil.eval and to=function"""
+        with self.assertRaises(TypeError):
+            tohil.eval("list 1 2 3", to=filter_minus_1)
 
 
 if __name__ == "__main__":

--- a/tests/test_tclobj.py
+++ b/tests/test_tclobj.py
@@ -40,7 +40,10 @@ class TestTclObj(unittest.TestCase):
         """exercise tohil.tclobj set()"""
         x = tohil.eval("list 1 2 3 4 5 5", to=tohil.tclobj)
 
-        self.assertEqual(sorted(set(x)), ["1", "2", "3", "4", "5"])
+        #NB we made tohil.tclobj unhashable because it's mutable
+        #NB is that right?  if we implement a hash function for it,
+        # this will work
+        #self.assertEqual(sorted(set(x)), ["1", "2", "3", "4", "5"])
 
     def test_tclobj6(self):
         """exercise tohil.tclobj tuple()"""
@@ -73,8 +76,6 @@ class TestTclObj(unittest.TestCase):
         """exercise tohil.tclobj subscripting, str(), and repr()"""
         x = tohil.eval("list 1 2 3 4 5", to=tohil.tclobj)
         self.assertEqual(str(x[2]), "3")
-        self.assertEqual(repr(x[2]), "'3'")
-        x.to = tohil.tclobj
         self.assertEqual(repr(x[2]), "<tohil.tclobj: '3'>")
 
     def test_tclobj11(self):


### PR DESCRIPTION
* to= conversions now default to tohil.tclobj instead of str when none is specified.
* python subinterpreters are now deleted when the associated tcl interpreter is deleted.
* version bump to 4.0.0 (but 4.0.0 hasn't been released yet.)
* greatly improved documentation.