### PR TITLE
tclobj iterator leak fix; new tohil.result function; error message improvements; improved docs

### DIFF
--- a/Doc/README.md
+++ b/Doc/README.md
@@ -1,0 +1,26 @@
+
+This is the Doc directory for tohil.
+
+You're going to need to install sphinx.
+
+You'll need to install the Tohil Docs Sphinx Theme, from
+https://github.com/flightaware/tohil-docs-theme
+
+It contains documentation patterned after Python's own documentation,
+using reStructturedText markup, and using Sphinx to process it.
+
+You'll need to make a data dir under Doc and touch a file
+in there called refcounts.dat.
+
+After that, from the command line you should be able to do a
+
+	make html
+
+...to create an html document tree of the Tohil rst docs.
+
+    make serve 
+
+...will launch Python's simple webserver to serve the built docs.
+This is for developers.
+
+

--- a/Doc/reference/tohil_types.rst
+++ b/Doc/reference/tohil_types.rst
@@ -15,8 +15,8 @@ The principal tohil types are *tclobj* and *tcldict*.  There are a few additiona
 types for iterators and exceptions.
 
 Tclobjs and tcldicts are mutable.  As with native Python types, methods that add,
-subtract, or rearrange their members in place, and don't return a specific item, type
-return ``None`` rather than the collection instance itself.
+subtract, or rearrange their members in place, and don't return a specific
+item, returning ``None`` rather than the collection instance itself.
 
 Some operations are supported by both object types; in particular,
 they can be compared for equality, tested for truth
@@ -29,15 +29,15 @@ numeric), including as a source or target of in-place arithmetic.
 
 Tclobjs and tcldicts are very flexible in terms of what they can be
 constructed from.  A tclobj can be created as an empty Tcl object, or
-from a Python None object, a Python boolean, int, float, or string object.
-They can further be created from Pyton lists, tuples, sets, dicts, sequences
-and maps, and Unicode translations should work fine.
+from a Python None object, a Python boolean, int, float, or string,
+a Python list, tuple, set, dict, sequence
+or map, and Unicode/UTF-8 translations should work fine.
 
 
 .. _tohil-truth:
 
-Truth Value Testing
-===================
+Testing Tclobj Truth Values
+============================
 
 .. index::
    statement: if
@@ -95,10 +95,11 @@ this could be high overhead for large and/or very complicated structures.
 
 .. _tohil_numeric:
 
-Using Tohil tclobjs and tcldicts as Numeric Types
-=================================================
+Using Tohil tclobjs as Numeric Types
+====================================
 
-Tohil tclobjs can be freely used where integers or floating
+Tohil tclobjs can be freely used in Python code
+where integers or floating
 point numbers are needed.  The underlying Tcl object will be
 requested using Tcl standard library routines, causing a fetch
 of the cached representation if the cached representation is of
@@ -112,8 +113,8 @@ Bitwise Operations on Tohil Types
 ---------------------------------
 
 Tohil tclobj objects can be freely used as a source for boolean
-operations and shift counts.  Left and right shift, "and", "or",
-"exclusive or", "invert", 
+operations and shift counts.  Bitwise and, or, exclusive or,
+left and right shift, invert, and absolute value are supported.
 
 Attempting bitwise operations on a tclobj that isn't or can't
 be converted into an integer will fail with a TypeError exception raised.
@@ -124,10 +125,10 @@ be converted into an integer will fail with a TypeError exception raised.
 tclobjs as lists
 ================
 
-Tclobjs whose internal contents are valid tcl lists, can be largely
-treated as python lists.
+Tclobjs whose internal contents are valid Tcl lists, can be largely
+treated as Python lists.
 
-Tclobjs as lists can be created from Python based on strings,
+Tclobjs-as-lists can be created from Python based on strings,
 lists, tuples, sets, even dicts.  It's pretty cool.
 
 The common sequence operations of ``in`` and ``not in`` work fine, while
@@ -145,6 +146,10 @@ Tclobjs are mutable; you can assign an element with ``s[i] = x``, append
 an element with ``s.append(x)``, extend *s* with the contents of a Python
 list, set, tuple, int, float, etc, or another tclobj, with
 ``s.extend(x)``.
+
+(Because tclobjs are mutable, they cannot be directly used as a key
+in a dictionary or a value in a set.  If you need to use one as a key,
+wrap it with *str()* or something.)
 
 You can clear a tclobj or tcldict using ``s.clear()``, and pop items
 from the list using ``s.pop([i])``.
@@ -233,7 +238,8 @@ An example that uses most of the list methods::
 Mapping Types --- :class:`tcldict`
 ==================================
 
-Tcldicts are a Python type that manages a Tcl object of a dictionary structure. They can be used in a way fairly close to Python dicts.
+Tcldicts are a Python type that manages a Tcl object of a dictionary structure.
+Most things you can do with a Python dicts you can do with a tcldict.
 
 However, unlike dicts, tcldicts are recursive.  From Python, if a key is
 specified as a Python list, the Tcl dictionary is managed as a hierarchy

--- a/Doc/tutorial/tohil_python.rst
+++ b/Doc/tutorial/tohil_python.rst
@@ -66,7 +66,7 @@ are equivalent:
    >>> tohil.package_require('Tclx', '8.6')
    >>> tohil.package_require('Tclx',version='8.6')
 
-Experienced Python users without a lot of Tcl experience may be surprised
+Experienced Python developers without a lot of Tcl experience may be surprised
 by Tcl's leniency when it comes to data types.
 
 Here we request a Tcl package with the version number specified as
@@ -77,7 +77,11 @@ floating point.  It works fine.
    >>> tohil.package_require('Tclx', 8.6)
 
 Another one you'd end up doing a lot is ``tohil.eval("source file.tcl")``.  For that
-we provide the slightly less paper-cutty ``tohil.source("file.tcl")``.
+we provide the slightly less paper-cutty...
+
+::
+
+   >>> tohil.source("file.tcl")
 
 
 **************
@@ -144,8 +148,8 @@ specific Python datatype.
 tohil.getvar and tohil.setvar
 ******************************
 
-Python has direct access to Tcl variables and arrays using *tohil.getvar*.
-Likewise, *tohil.setvar* can set them.
+Python has direct access to Tcl variables and array elements
+using *tohil.getvar*.  Likewise, *tohil.setvar* can set them.
 
 ::
 
@@ -168,12 +172,12 @@ Likewise, *tohil.setvar* can set them.
    >>> tohil.getvar("x(e)")
    Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-   RuntimeError: can't read "x(e)": no such element in array
+   NameError: can't read "x(e)": no such element in array
 
 As you can see, it's an error to try to get a variable or array element
-that isn't there.  You can use tohil.exists to see if the variable is there,
-or trap the Python exception, or make use of *tohil.getvar*'s handy
-*default* keyword-only argument.
+that doesn't exist.  You can use *tohil.exists* to see if the variable
+exists, or trap the Python exception, or make use of *tohil.getvar*'s handy
+*default* keyword-only argument:
 
 ::
 
@@ -188,9 +192,7 @@ or trap the Python exception, or make use of *tohil.getvar*'s handy
 tohil.exists
 ****************
 
-Since it is an error to try to *tohil.getvar* a variable that doesn't exist,
-you can trap the request from Python and handle the exception,
-or use *tohil.exists* to see if the var or array element exist.
+You can use *tohil.exists* to see if a variable or array element exists:
 
 ::
 
@@ -215,8 +217,8 @@ to increment it.
 If the contents of the variable preclude it being used as an int, a Python
 TypeError exception is thrown.
 
-An optional position argument specifies an increment amount.  The default
-increment is 1.
+An optional position argument specifies the amount to increment by.
+The default increment is 1.
 Negative increments are permitted.
 The increment amount can also be specified as
 a keyword argument, using "incr".
@@ -244,7 +246,7 @@ arrays in the Tcl interpreter.
    >>> tohil.getvar("x(e)")
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
-   RuntimeError: can't read "x(e)": no such element in array
+   NameError: can't read "x(e)": no such element in array
 
 * Unset takes an arbitrary number of arguments, including zero.
 * Unsetting an array element uses Tcl subscript notation, for example
@@ -298,5 +300,3 @@ back by sending an end-of-file.
 tcldict
 tclobj
 tclvar
-=======
->>>>>>> e7333ccf4bcd0c70073e5b93170683cd3d9560f6

--- a/Doc/whatsnew/4.0.rst
+++ b/Doc/whatsnew/4.0.rst
@@ -10,8 +10,9 @@ tclobj default return
 ==========================
 
 This is a biggie.  Many Tohil functions accept a *to=* argument
-where you can specify a Python data type to convert the return
-of the call to.  In the past, and going forward, you could
+where you can specify a Python data type to convert a tcl
+object returned from doing a call or accessing tcl data.
+In the past, and going forward, you could
 set a return type of *str*, *int*, *bool*, *float*, *list*, *set*,
 *dict*, *tuple*, *tohil.tclobj* or *tohil.tcldict*.
 
@@ -19,10 +20,11 @@ Prior to Tohil 4, if you didn't set a *to=* return type, the default
 return type was string, *str*.  This seemed perfectly reasonable.
 After all, in Tcl, despite it having internal objects and maintaining
 in them a cache of a conversion to a data type such as integer, list,
-etc, everything is a string.
+etc, in Tcl "every value is a string."
 
-However, as we have enhanced and extended our tclobj type, it has become
-easier and easier to use it from Python with no funny business.
+However, as we have enhanced and extended Tohil's tclobj type,
+it has become ever easier to use tclobjs directly from Python
+with no funny business.
 You can get a tclobj's string representation with *str()*, integer
 with *int()*, float with *float()*, list with *list()*, and others.
 You can use Python list notation to access and manipulate elements

--- a/Doc/whatsnew/4.0.rst
+++ b/Doc/whatsnew/4.0.rst
@@ -12,13 +12,13 @@ tclobj default return
 This is a biggie.  Many Tohil functions accept a *to=* argument
 where you can specify a Python data type to convert a tcl
 object returned from doing a call or accessing tcl data.
-In the past, and going forward, you could
+You can
 set a return type of *str*, *int*, *bool*, *float*, *list*, *set*,
 *dict*, *tuple*, *tohil.tclobj* or *tohil.tcldict*.
 
 Prior to Tohil 4, if you didn't set a *to=* return type, the default
-return type was string, *str*.  This seemed perfectly reasonable.
-After all, in Tcl, despite it having internal objects and maintaining
+return type was string, *str*.  This seemed perfectly reasonable;
+after all, in Tcl, despite it having internal objects and maintaining
 in them a cache of a conversion to a data type such as integer, list,
 etc, in Tcl "every value is a string."
 
@@ -30,17 +30,19 @@ with *int()*, float with *float()*, list with *list()*, and others.
 You can use Python list notation to access and manipulate elements
 of tclobjs when they contain lists, can iterate over them, etc.
 
-Since our tclobj type implements Python's number protocol, if tclobjs
+Since Tohil's tclobj type implements Python's number protocol, if tclobjs
 contain numbers, they can be used in calculations without
-any conversion required.
+conversion via *int()* and *float()*.
 
 Consequently starting in Tohil 4, the default *to* return is now
 *tohil.tclobj*.  In our experience, and a little bit to our surprise,
-most Python code that uses Tohil will "just work", without modifications.
+most Python code that uses Tohil will "just work" without modifications.
 
 If, though, for instance, you didn't specify a default return and then
-knowing you would get a str invoked string methods on the str, you'll
-get an error if the tclobj doesn't implement those methods.  In this
+knowing you would get a str invoked string methods on the str that
+was returned, you'll
+probably get an error because the tclobj doesn't implement all of the
+str datatype's methods.  In this
 case, adding a *to=str* to the Tohil call will be sufficient to get
 your code working under Tohil 4.
 
@@ -106,12 +108,14 @@ A function can now be specified in a to= arg
 The *to=* argument to a Tohil function such as *tohil.eval*,
 *tohil.call*, etc, has until now been required to specify a
 Python data type such as *int*, *float*, *str*, *tohil.tclobj*,
-etc, it can now also be specified as a callable function.
+etc. It can now also be specified as a callable function.
 
-If the *to* argument is a callable function, Tohil will call it
+If the *to* argument is not a recognized data type but is
+a callable function, Tohil will call that function
 with one argument, a tclobj object containing the object
-to be returned, and it is up to the function to manipulate the
-object in some way.  Whatever the function returns is what the
+to be returned, and it is expected that the function will
+manipulate the object in some way and then return a result.
+Whatever the function returns is what the
 relevant tohil function will return.
 
 This provides an additional way for a Tohil developer to customize

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -669,18 +669,18 @@ static void
 tohil_setup_subinterp(Tcl_Interp *interp, enum SubinterpType subtype)
 {
     switch (subtype) {
-        case PythonParent:
-            tohil_set_subinterp(interp, PyThreadState_Get());
-            Tcl_SetAssocData(interp, ASSOC_PYPARENT_NAME, NULL, (ClientData)1);
-            break;
+    case PythonParent:
+        tohil_set_subinterp(interp, PyThreadState_Get());
+        Tcl_SetAssocData(interp, ASSOC_PYPARENT_NAME, NULL, (ClientData)1);
+        break;
 
-        case TclParent:
-            tohil_set_subinterp(interp, PyThreadState_Get());
-            break;
+    case TclParent:
+        tohil_set_subinterp(interp, PyThreadState_Get());
+        break;
 
-        case TclChild:
-            tohil_set_subinterp(interp, Py_NewInterpreter());
-            break;
+    case TclChild:
+        tohil_set_subinterp(interp, Py_NewInterpreter());
+        break;
     }
 }
 
@@ -3749,7 +3749,8 @@ tohil_python_return(Tcl_Interp *interp, int tcl_result, PyObject *toType, Tcl_Ob
         return callResult;
     }
 
-    PyErr_SetString(PyExc_TypeError, "'to' conversion type must be str, int, bool, float, list, set, dict, tuple, tohil.tclobj, tohil.tcldict, or a callble python function taking a tclobj argument and returning something");
+    PyErr_SetString(PyExc_TypeError, "'to' conversion type must be str, int, bool, float, list, set, dict, tuple, tohil.tclobj, tohil.tcldict, or a "
+                                     "callble python function taking a tclobj argument and returning something");
     return NULL;
 }
 
@@ -4078,7 +4079,6 @@ tohil_result(PyObject *m, PyObject *args, PyObject *kwargs)
     return tohil_python_return(interp, TCL_OK, to, obj);
 }
 
-
 //
 // python C extension structure defining functions
 //
@@ -4217,7 +4217,7 @@ Tohil_Init(Tcl_Interp *interp)
     if (Tcl_CreateObjCommand(interp, "::tohil::eval", (Tcl_ObjCmdProc *)TohilEval_Cmd, (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL) == NULL)
         return TCL_ERROR;
 
-    if (Tcl_CreateObjCommand(interp, "::tohil::exec", (Tcl_ObjCmdProc *) TohilExec_Cmd, (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL) == NULL)
+    if (Tcl_CreateObjCommand(interp, "::tohil::exec", (Tcl_ObjCmdProc *)TohilExec_Cmd, (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL) == NULL)
         return TCL_ERROR;
 
     if (Tcl_CreateObjCommand(interp, "::tohil::call", (Tcl_ObjCmdProc *)TohilCall_Cmd, (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL) == NULL)

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -3653,6 +3653,13 @@ tohil_python_return(Tcl_Interp *interp, int tcl_result, PyObject *toType, Tcl_Ob
         // dig out tcl error information and create a tohil tcldict containing it
         // (Tcl_GetReturnOptions returns a tcl dict object)
         Tcl_Obj *returnOptionsObj = Tcl_GetReturnOptions(interp, tcl_result);
+
+        // the tcl errorstack is big and replicates a lot of stuff,
+        // just get rid of it.  if you want it, put this back in.
+        Tcl_Obj *keyObj = Tcl_NewStringObj("-errorstack", -1);
+        Tcl_DictObjRemove(NULL, returnOptionsObj, keyObj);
+        Tcl_DecrRefCount(keyObj);
+
         PyObject *pReturnOptionsObj = TohilTclDict_FromTclObj(interp, returnOptionsObj);
 
         // construct a two-element tuple comprising the interpreter result

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -855,18 +855,11 @@ TohilExecEvalPython(int startSymbol, Tcl_Interp *interp, int objc, Tcl_Obj *cons
     Tcl_DString ds;
     const char *cmd = tohil_TclObjToUTF8DString(interp, objv[1], &ds);
 
-    PyObject *code = Py_CompileStringExFlags(cmd, "tohil", startSymbol, NULL, -1);
-    Tcl_DStringFree(&ds);
-
-    if (code == NULL) {
-        return Tohil_ReturnExceptionToTcl(interp, "while compiling python eval code");
-    }
-
+    // evaluate the command according to the start symbol
     PyObject *main_module = PyImport_AddModule("__main__");
     PyObject *global_dict = PyModule_GetDict(main_module);
-    PyObject *pyobj = PyEval_EvalCode(code, global_dict, global_dict);
-
-    Py_XDECREF(code);
+    PyObject *pyobj = PyRun_StringFlags(cmd, startSymbol, global_dict, global_dict, 0);
+    Tcl_DStringFree(&ds);
 
     if (pyobj == NULL) {
         return Tohil_ReturnExceptionToTcl(interp, "while evaluating python code");

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -3690,14 +3690,6 @@ tohil_python_return(Tcl_Interp *interp, int tcl_result, PyObject *toType, Tcl_Ob
     }
     // printf("tohil_python_return called: tcl result %d, to=%s, resulObj '%s'\n", tcl_result, toString, Tcl_GetString(resultObj));
 
-    // if there's no "to" specified and the result object is empty,
-    // just return None.  This is experimental.  Not sure about it.
-    if (0 && toType == NULL) {
-        if (resultObj->bytes != NULL && resultObj->length == 0) {
-            Py_RETURN_NONE;
-        }
-    }
-
     if (toType == NULL || STREQU(toString, "tohil.tclobj")) {
         return TohilTclObj_FromTclObj(interp, resultObj);
     }

--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -43,10 +43,10 @@ def handle_exception(exception_type, val, traceback_object=None):
     error_code = ["PYTHON", exception_type.__name__, val]
 
     if traceback_object is None:
-        tb_list = list()
+        error_info = "\nfrom python code executed by tohil"
     else:
         tb_list = traceback.format_tb(traceback_object)
-    error_info = "\nfrom python code executed by tohil" + " ".join(tb_list).rstrip()
+        error_info = "\nfrom python code executed by tohil\n" + " ".join(tb_list).rstrip()
     return error_code, error_info
 
 

--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -292,6 +292,7 @@ from tohil._tohil import (
     tcldict,
     convert,
     incr,
+    result,
     __version__,
 )
 

--- a/tests/tohil.test
+++ b/tests/tohil.test
@@ -25,7 +25,7 @@ test tohil_eval-1.3 {correct usage of eval} \
 test tohil_eval-1.4 {incorrect usage of eval} \
 	-body {tohil::eval "a = 5"} \
 	-returnCodes error \
-	-result {invalid syntax (tohil, line 1)}
+	-result {invalid syntax (<string>, line 1)}
 
 # =========
 # tohil::exec
@@ -193,7 +193,7 @@ test tohil_call-1.11 {call of nonexistent functions} \
 test tohil_call-1.12 {call of nonexistent object methods} \
 	-body {tohil::eval {a = "aaa"}} \
 	-returnCodes error \
-	-result {invalid syntax (tohil, line 1)}
+	-result {invalid syntax (<string>, line 1)}
 
 # =========
 # TYPES


### PR DESCRIPTION
* iterating on a tclobj would result in a leaked reference of the tcl  list object.  that is now fixed.  that also caused some strange  behavior.
* new tohil.result() python-side function returns the interpreter result object.
* stop propagating tcl -errorstack into TclError object  (The Tcl errorstack is big and replicates info already included in the rest of the TclError object.  This removes it.  It makes the TclError object considerably more manageable to the human trying to look at it.
* improvements in error messages when Tcl errors are raised as Python exceptions by Tohil.
* numerous improvements to the documentation.