### PR TITLE
Provide a way to pass None when using tohil::call

### DIFF
--- a/Doc/reference/tohil_tcl_functions.rst
+++ b/Doc/reference/tohil_tcl_functions.rst
@@ -22,6 +22,11 @@ from Tcl interpreter, the following commands are available:
    If *-kwlist list* is specified, *list* contains key-value pairs
    that will be passed to the function as named parameters.
 
+   When you use tohil::call, Tohil converts all of your arguments
+   to Python Unicode, unless an argument is comprised of the special
+   sentinel `tohil::NONE`, in which case the Python "None" data type
+   is substituted in place of that argument.
+
 .. function:: tohil::eval evalString
 
    *evalString* contains a valid Python expression.  Tohil

--- a/Doc/tutorial/tohil_tcl.rst
+++ b/Doc/tutorial/tohil_tcl.rst
@@ -141,8 +141,8 @@ or whatever, that unless you are very careful, various characters
 can cause your Python not to parse properly.  For example, a single
 quote in a name, quotes in general, and other stuff.
 
-Tohil provides *tohil::call* to make it possible to call a Python
-function and make sure that the arguments you pass to the function
+Tohil provides *tohil::call* to provide a way to call a Python
+function while making sure that the arguments you pass to the function
 are not interpreted by Python along the way.
 
 
@@ -151,9 +151,9 @@ arguments, without having to pass it through Python's eval or exec and running
 the risk that Python metacharacters appearing in the data will cause quoting
 problems, accidental code execution, etc.
 
-tohil::import provides a way to import Python modules, although it's not much
-different from doing a tohil::exec "import module"
-
+When you use tohil::call, Tohil converts all of your arguments to Python
+Unicode, unless an argument is comprised of the special sentinel `tohil::NONE`,
+in which case that argument is replaced by the Python "None" data type.
 
 ***************
 tohil::interact

--- a/tests/tohil.test
+++ b/tests/tohil.test
@@ -195,6 +195,27 @@ test tohil_call-1.12 {call of nonexistent object methods} \
 	-returnCodes error \
 	-result {invalid syntax (<string>, line 1)}
 
+test tohil_call-1.13 {call with tohil::NONE sentinel for None type} \
+	-body {
+		tohil::exec {def a(x): return x == None}
+		tohil::call a tohil::NONE
+	} \
+	-result 1
+
+test tohil_call-1.14 {call with not quite tohil::NONE sentinel} \
+	-body {
+		tohil::exec {def a(x): return x == None}
+		tohil::call a tohil::NONEzee
+	} \
+	-result 0
+
+test tohil_call-1.15 {call with extra tohil::NONE sentinel action} \
+	-body {
+		tohil::exec {def a(x, y, z): return str(x) + ' ' + str(y) + ' ' + str(z)}
+		tohil::call a tohil::NONE 42 tohil::NONE
+	} \
+	-result "None 42 None"
+
 # =========
 # TYPES
 # =========


### PR DESCRIPTION
For each argument to a Python function called from Tcl using
tohil::call, if the value of the argument is the special sentinel
"tohil::NONE", tohil::call will pass the python None object that
argument's value.

Fix for #37 