### PR TITLE
tclvar fixes

### DIFF
--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1526,7 +1526,7 @@ TohilTclObj_lappend(TohilTclObj *self, PyObject *pObject)
         return NULL;
     }
 
-    Tcl_Obj *writeObj = TohilTclObj_writable_objptr(self);
+    Tcl_Obj *writeObj = TohilTclObj_objptr(self);
     if (writeObj == NULL)
         return NULL;
 
@@ -1555,7 +1555,7 @@ TohilTclObj_lappend(TohilTclObj *self, PyObject *pObject)
 static PyObject *
 TohilTclObj_lappend_list(TohilTclObj *self, PyObject *pObject)
 {
-    Tcl_Obj *writeObj = TohilTclObj_writable_objptr(self);
+    Tcl_Obj *writeObj = TohilTclObj_objptr(self);
     if (writeObj == NULL)
         return NULL;
 
@@ -1645,7 +1645,8 @@ TohilTclObj_type(TohilTclObj *self, PyObject *Py_UNUSED(ignored))
 }
 
 //
-// insert something to the tclobj list
+// insert an element into the tclobj list at the specified
+// location, like l.insert(0, "string")
 //
 static PyObject *
 TohilTclObj_insert(TohilTclObj *self, PyObject *args, PyObject *kwargs)
@@ -1662,7 +1663,7 @@ TohilTclObj_insert(TohilTclObj *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
-    Tcl_Obj *writeObj = TohilTclObj_writable_objptr(self);
+    Tcl_Obj *writeObj = TohilTclObj_objptr(self);
     if (writeObj == NULL)
         return NULL;
 
@@ -3348,7 +3349,7 @@ TohilTclDict_setitem(TohilTclObj *self, PyObject *keys, PyObject *pValue)
     // we are about to try to modify the object, so if it's shared we need to copy
     TohilTclObj_dup_if_shared(self);
 
-    Tcl_Obj *writeObj = TohilTclObj_writable_objptr(self);
+    Tcl_Obj *writeObj = TohilTclObj_objptr(self);
     if (writeObj == NULL)
         return -1;
 

--- a/tests/test_tclvars.py
+++ b/tests/test_tclvars.py
@@ -72,6 +72,46 @@ class TclVarTests(unittest.TestCase):
         assert(str(tl) == tohil.getvar(list_name))
         assert(list(tl) == tohil.getvar(list_name, to=list))
 
+    def test_tclvar4(self):
+        """exercise tclobj insert method"""
+        ns_name = "::tohil_test"
+        list_name = ns_name + "::varsync_list"
+
+        tohil.unset(list_name)
+        tl = tohil.tclvar(list_name, default="1 2 3 4 5")
+        assert(tl[0] == 1)
+        self.assertEqual(len(tl), 5)
+        tl.insert(0, 1)
+        self.assertEqual(len(tl), 6)
+        self.assertEqual(tl[0], 1)
+        self.assertEqual(tl[5], 5)
+
+    def test_tclvar5(self):
+        """exercise tclobj append method"""
+        ns_name = "::tohil_test"
+        list_name = ns_name + "::varsync_list"
+
+        tohil.unset(list_name)
+        tl = tohil.tclvar(list_name, default="1 2 3 4 5")
+        assert(tl[0] == 1)
+        self.assertEqual(len(tl), 5)
+        tl.append('6')
+        self.assertEqual(len(tl), 6)
+        self.assertEqual(tl[0], 1)
+        self.assertEqual(tl[5], 6)
+
+    def test_tclvar6(self):
+        """exercise tclobj extend method"""
+        ns_name = "::tohil_test"
+        list_name = ns_name + "::varsync_list"
+
+        tohil.unset(list_name)
+        tl = tohil.tclvar(list_name, default="1 2 3 4 5")
+        tl.extend(tohil.tclobj("1 2 3"))
+        self.assertEqual(len(tl), 8)
+        self.assertEqual(tl[0], 1)
+        self.assertEqual(tl[7], 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
fix improper overwrites for tclobj methods when the object is bound to a var (tclvar)
    
There were errors in how tclvars (tclobjs bound to vars) handled some methods such as insert, pop, append, and extend, resulting in the data getting overwritten
    
We introduce a new routine, TohilTclObj_objptr_for_write, that returns a TclObj * that we can mutate.  It is either from the tclobj object directly or from the tcl variable defined in the tclobj (tclvar), and it's been pre-checked to see if it's shared and if it is, it's been duplicated properly such that we can mutate it (it is no longer shared.)
    
We also subsume a couple places where tohil C code "got it right" but in an ad hoc manner with calls to the new function.
    
fixes issue #38