### PR TITLE
Allow for directly linking Tcl commands to Python functions

### DIFF
--- a/Doc/reference/tohil_python_functions.rst
+++ b/Doc/reference/tohil_python_functions.rst
@@ -139,6 +139,13 @@ when the tohil package has been imported.
    This is a shortcut for
    ``tohil.eval(f"package require {packageName} {versionID}")``.
 
+.. function:: tohil.register_callback(name, callback)
+
+   Create a Tcl command with the given name linked to the given Python
+   callable. When the command is invoked, it will directly invoke the callback,
+   passing along any arguments. This is useful in cases where the Tcl event
+   loop is utilized to execute code asynchronous.
+
 .. function:: tohil.result([to=type])
 
    Return the Tcl interpreter result object.

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -4148,6 +4148,7 @@ tohil_register_callback(PyObject *m, PyObject *args, PyObject *kwargs)
     Tcl_DString ds;
     char *tcl_name = tohil_UTF8ToTclDString(interp, name, -1, &ds);
     data = PyMem_NEW(PythonCmd_ClientData, 1);
+    Py_INCREF(callback);
     data->func = callback;
     Tcl_CreateObjCommand(interp, tcl_name, PythonCmd, (ClientData)data, NULL);
     Tcl_DStringFree(&ds);

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -4079,6 +4079,84 @@ tohil_result(PyObject *m, PyObject *args, PyObject *kwargs)
     return tohil_python_return(interp, TCL_OK, to, obj);
 }
 
+
+
+/* Client data struct */
+typedef struct {
+    PyObject *func;
+} PythonCmd_ClientData;
+
+
+/* This is the Tcl command that acts as a wrapper for Python
+ * function or method.
+ */
+static int
+PythonCmd(ClientData clientData, Tcl_Interp *interp,
+          int objc, Tcl_Obj *const objv[])
+{
+    PythonCmd_ClientData *data = (PythonCmd_ClientData *)clientData;
+    PyObject *args, *res;
+    int i;
+    Tcl_Obj *obj_res;
+
+    /* Create argument tuple (objv1, ..., objvN) */
+    if (!(args = PyTuple_New(objc - 1)))
+        return TCL_ERROR;
+
+    for (i = 0; i < (objc - 1); i++) {
+        Tcl_DString ds;
+        PyObject *s = Py_BuildValue("s", tohil_TclObjToUTF8DString(interp, objv[i + 1], &ds));
+        Tcl_DStringFree(&ds);
+        if (!s) {
+            Py_DECREF(args);
+            return TCL_ERROR;
+        }
+        PyTuple_SET_ITEM(args, i, s);
+    }
+
+    res = PyObject_Call(data->func, args, NULL);
+    Py_DECREF(args);
+
+    if (res == NULL)
+        return TCL_ERROR;
+
+    obj_res = _pyObjToTcl(interp, res);
+    if (obj_res == NULL) {
+        Py_DECREF(res);
+        return TCL_ERROR;
+    }
+    Tcl_SetObjResult(interp, obj_res);
+    Py_DECREF(res);
+
+    return TCL_OK;
+}
+
+static PyObject *
+tohil_register_callback(PyObject *m, PyObject *args, PyObject *kwargs)
+{
+    Tcl_Interp *interp = tohilstate(m)->interp;
+    PythonCmd_ClientData *data;
+    static char *kwlist[] = {"name", "callback", NULL};
+    PyObject *callback = NULL;
+    char *name = NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sO", kwlist, &name, &callback)) return NULL;
+    if (!PyCallable_Check(callback)) {
+        PyErr_SetString(PyExc_RuntimeError, "callback argument is not callable");
+        return NULL;
+    }
+
+    Tcl_DString ds;
+    char *tcl_name = tohil_UTF8ToTclDString(interp, name, -1, &ds);
+    data = PyMem_NEW(PythonCmd_ClientData, 1);
+    data->func = callback;
+    Tcl_CreateObjCommand(interp, tcl_name, PythonCmd, (ClientData)data, NULL);
+    Tcl_DStringFree(&ds);
+    Py_RETURN_NONE;
+}
+
+
+
+
 //
 // python C extension structure defining functions
 //
@@ -4097,6 +4175,8 @@ static PyMethodDef TohilMethods[] = {
      "convert python to tcl object then to whatever to= says or string and return"},
     {"call", (PyCFunction)tohil_call, METH_VARARGS | METH_KEYWORDS, "invoke a tcl command with arguments"},
     {"result", (PyCFunction)tohil_result, METH_VARARGS | METH_KEYWORDS, "return the tcl interpreter result object"},
+    {"register_callback", (PyCFunction)tohil_register_callback, METH_VARARGS | METH_KEYWORDS,
+    "Register a Python callable so it can be called directly from Tcl as a command"},
     {NULL, NULL, 0, NULL} /* Sentinel */
 };
 

--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -293,6 +293,7 @@ from tohil._tohil import (
     convert,
     incr,
     result,
+    register_callback,
     __version__,
 )
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,47 @@
+import time
+import unittest
+
+import tohil
+
+class TestRegister(unittest.TestCase):
+    def test_simple(self):
+        def callback(arg):
+            return arg
+        tohil.register_callback("pycallback", callback)
+        self.assertEqual(tohil.call("pycallback", 1), tohil.tclobj(1))
+
+    def test_var_args(self):
+        def callback(*args):
+            return args
+        tohil.register_callback("pycallback", callback)
+        self.assertEqual(tohil.call("pycallback", 1, 2, 3), ("1", "2", "3"))
+
+    def test_kw_args(self):
+        # tohil.call ignores kwargs and so they'll never make it back to the
+        # callback
+        def callback(*args, **kwargs):
+            return args, kwargs
+        tohil.register_callback("pycallback", callback)
+        self.assertEqual(tohil.call("pycallback", 1, akwarg=2), ((1,), {}))
+
+    @unittest.skip("segfaults")
+    def test_missing_req_arg(self):
+        # TODO: This segfaults when it should produce a reasonable error
+        def callback(required):
+            return required
+        tohil.register_callback("pycallback", callback)
+        self.assertEqual(tohil.call("pycallback"), "")
+
+    def test_after_func(self):
+        flag = False
+        def setflag():
+            nonlocal flag
+            flag = True
+        tohil.register_callback("setflag", setflag)
+        tohil.call("after", 100, "setflag")
+        while not flag:
+            tohil.call("update")
+            tohil.call("update", "idletasks")
+            time.sleep(.05)
+        assert flag
+


### PR DESCRIPTION
Mostly cribbed from tkinter which has similar functionality. Useful in event loop cases where a Tcl callback can be specified.