### PR TITLE
make tohil::call support builtins

### DIFF
--- a/tests/tohil.test
+++ b/tests/tohil.test
@@ -188,7 +188,7 @@ test tohil_call-1.10 {stacked call exception} \
 test tohil_call-1.11 {call of nonexistent functions} \
 	-body {tohil::call aosdin} \
 	-returnCodes error \
-	-result {module '__main__' has no attribute 'aosdin'}
+	-result {name 'aosdin' is not defined.}
 
 test tohil_call-1.12 {call of nonexistent object methods} \
 	-body {tohil::eval {a = "aaa"}} \
@@ -215,6 +215,12 @@ test tohil_call-1.15 {call with extra tohil::NONE sentinel action} \
 		tohil::call a tohil::NONE 42 tohil::NONE
 	} \
 	-result "None 42 None"
+
+test tohil_call-1.16 {make sure tohil::call of python builtins works} \
+	-body {
+		tohil::call int 255
+	} \
+	-result 255
 
 # =========
 # TYPES


### PR DESCRIPTION
The Tcl-side tohil::call function provides a way to call a Python
function while making sure that the arguments passed to the function
are not interpreted by Python.

Because it didn't look in builtins if it couldn't find
the function in dunder main, stuff like "tohil::call print foo"
didn't work.

We now look in builtins after exhausting our other options.

Thanks to Oliver Jowett (obj) for a consult.

Fixes issue #39.