### PR TITLE
Correct behavior of __iter__() on iterators

### DIFF
--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2244,7 +2244,7 @@ static PyTypeObject TohilTclObj_IterType = {
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_doc = "tohil tclobj iterator type",
     .tp_dealloc = (destructor)TohilTclObjIter_dealloc,
-    .tp_iter = (getiterfunc)TohilTclObjIter,
+    .tp_iter = (getiterfunc)PyObject_SelfIter,
     .tp_iternext = (iternextfunc)TohilTclObj_iternext,
 };
 

--- a/tests/test_tclobj.py
+++ b/tests/test_tclobj.py
@@ -251,5 +251,17 @@ class TestTclObj(unittest.TestCase):
         with self.assertRaises(IndexError):
             t.pop()
 
+    def test_tclobj25(self):
+        """tohil.tclobj dict wrapping tests"""
+        # This isn't recommended (you should use the to= kwarg), but it works
+        self.assertEqual(dict(tohil.tclobj()), {})
+        # And here's why it's not recommended
+        with self.assertRaises(ValueError):
+            dict(tohil.tclobj("1 2"))
+        with self.assertRaises(TypeError):
+            # iterating on the tclobj gives us more tclobjs, which aren't
+            # hashable and so cannot be keys
+            dict(tohil.tclobj("{1 2}"))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
They should simply return themselves. Fortunately Python's got a helper
for that. Fixes #34.