### PR TITLE
Make "package forget tohil; package require tohil" work and allow the shared library to be unloaded using Tcl's "unload"

### DIFF
--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -4455,10 +4455,9 @@ Tohil_Unload(Tcl_Interp *interp, int flags)
     Tcl_DeleteCommand(interp, "::tohil::interact");
 
     if (flags & TCL_UNLOAD_DETACH_FROM_INTERPRETER) {
-        printf("tohil unload detach from interpreter\n");
-        // pass
+        // printf("tohil unload detach from interpreter\n");
     } else if (flags & TCL_UNLOAD_DETACH_FROM_PROCESS) {
-        printf("tohil unload detach from process\n");
+        // printf("tohil unload detach from process\n");
         Py_FinalizeEx();
     } else {
         Tcl_SetResult(interp, "bug in tohil or some new feature of tcl unload it never heard of", TCL_STATIC);

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -4355,8 +4355,8 @@ Tohil_Init(Tcl_Interp *interp)
     if (Tcl_PkgRequire(interp, "Tcl", "8.6", 0) == NULL)
         return TCL_ERROR;
 
-    if (Tcl_PkgProvide(interp, "tohil", PACKAGE_VERSION) != TCL_OK)
-        return TCL_ERROR;
+    //if (Tcl_PkgProvide(interp, "tohil", PACKAGE_VERSION) != TCL_OK)
+    //    return TCL_ERROR;
 
     // if (Tcl_CreateNamespace(interp, "::tohil", NULL, NULL) == NULL)
     //    return TCL_ERROR;
@@ -4442,6 +4442,28 @@ Tohil_Init(Tcl_Interp *interp)
     if (Tcl_CreateObjCommand(interp, "::tohil::interact", (Tcl_ObjCmdProc *)TohilInteract_Cmd, (ClientData)NULL, (Tcl_CmdDeleteProc *)NULL) == NULL)
         return TCL_ERROR;
 
+    return TCL_OK;
+}
+
+int
+Tohil_Unload(Tcl_Interp *interp, int flags)
+{
+    Tcl_DeleteCommand(interp, "::tohil::eval");
+    Tcl_DeleteCommand(interp, "::tohil::exec");
+    Tcl_DeleteCommand(interp, "::tohil::call");
+    Tcl_DeleteCommand(interp, "::tohil::import");
+    Tcl_DeleteCommand(interp, "::tohil::interact");
+
+    if (flags & TCL_UNLOAD_DETACH_FROM_INTERPRETER) {
+        printf("tohil unload detach from interpreter\n");
+        // pass
+    } else if (flags & TCL_UNLOAD_DETACH_FROM_PROCESS) {
+        printf("tohil unload detach from process\n");
+        Py_FinalizeEx();
+    } else {
+        Tcl_SetResult(interp, "bug in tohil or some new feature of tcl unload it never heard of", TCL_STATIC);
+        return TCL_ERROR;
+    }
     return TCL_OK;
 }
 

--- a/pkgIndex.tcl.in
+++ b/pkgIndex.tcl.in
@@ -2,4 +2,4 @@
 # Tcl package index file
 #
 package ifneeded tohil @PACKAGE_VERSION@ \
-    [list load [file join $dir @PKG_LIB_FILE@] tohil]\n[list source [file join $dir tohil.tcl]]
+    [list load [file join $dir @PKG_LIB_FILE@] tohil]\n[list source [file join $dir tohil.tcl]]\n[list package provide tohil @PACKAGE_VERSION@]


### PR DESCRIPTION
Support "package forget tohil; package require tohil" by migrating from using Tcl_PkgProvide in the C code to using "package provide" in pkgIndex.tcl.in.

Also adds support for unloading the shared library using Tcl's "unload" command.

Hat tip to @pooryorick for the bug report and the solution.

Fixes Issue #52 