### PR TITLE
conform register_callback returns to standard practice

### DIFF
--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -4255,17 +4255,17 @@ PythonCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const ob
     Py_DECREF(args);
 
     if (res == NULL)
-        return TCL_ERROR;
+        return Tohil_ReturnExceptionToTcl(interp, "error in python object call");
 
     obj_res = _pyObjToTcl(interp, res);
     if (obj_res == NULL) {
         Py_DECREF(res);
-        return TCL_ERROR;
+        return Tohil_ReturnExceptionToTcl(interp, "error converting python object to tcl object");
     }
     Tcl_SetObjResult(interp, obj_res);
     Py_DECREF(res);
 
-    return TCL_OK;
+    return tohil_tcl_return(interp, TCL_OK);
 }
 
 static PyObject *

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -24,13 +24,19 @@ class TestRegister(unittest.TestCase):
         tohil.register_callback("pycallback", callback)
         self.assertEqual(tohil.call("pycallback", 1, akwarg=2), ((1,), {}))
 
-    @unittest.skip("segfaults")
     def test_missing_req_arg(self):
-        # TODO: This segfaults when it should produce a reasonable error
         def callback(required):
             return required
         tohil.register_callback("pycallback", callback)
-        self.assertEqual(tohil.call("pycallback"), "")
+        with self.assertRaises(tohil.TclError):
+            tohil.call("pycallback")
+
+    def test_too_many_args(self):
+        def callback(required):
+            return required
+        tohil.register_callback("pycallback", callback)
+        with self.assertRaises(tohil.TclError):
+            tohil.call("pycallback 1 2")
 
     def test_after_func(self):
         flag = False


### PR DESCRIPTION
At the point in PythonCmd where a null result was checked and TCL_ERROR returned, it instead ineeded to `return Tohil_ReturnExceptionToTcl(interp, "error in python object call");` to get all the stuff necessary to dig out the Python exception and return it as a Tcl error.

This fixes issue 57.