### PR TITLE
BCK-6281 Implement an un-indenter for embedded Python code passed to tohil::exec

### DIFF
--- a/Doc/reference/tohil_tcl_functions.rst
+++ b/Doc/reference/tohil_tcl_functions.rst
@@ -52,6 +52,11 @@ from Tcl interpreter, the following commands are available:
    to a string, or whatever, in the normal Python manner.
    *tohil::run*, in fact, provides a way to do this.
 
+   To make it easier to comply with Python indentation rules, if the first
+   nonblank line starts with whitespace, exec will un-indent the code block
+   so the first line is not indented at all and following lines are undented
+   to match.
+
 .. function:: tohil::import module
 
    Import the specified module into the globals of the Python interpreter.

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -166,15 +166,21 @@ static int tohil_UndentPython(Tcl_Interp *interp, char *string) {
         char c = *working_ptr++ = *code_ptr++;
         if(c == '\n') {
             indent_ptr = indent;
-            while(*indent_ptr) {
-		// Blank line, start over.
-		if(*code_ptr == '\n')
-                    break;
-                if(*indent_ptr++ != *code_ptr++) {
-                    Tcl_SetResult(interp, "indent missed spaces and tabs or something, we can't undent it", TCL_STATIC);
+            while(*indent_ptr && *code_ptr) {
+                // Look for mismatches
+                if(*indent_ptr != *code_ptr) {
+                    // Fast forward to end of line
+                    while(*code_ptr != '\n' && isspace(*code_ptr))
+			code_ptr++;
+                    // Mismatch on blank line, ignore
+                    if(*code_ptr == '\n')
+                        break;
+                    Tcl_SetResult(interp, "can't undent Python block (possibly mixed spaces and tabs)", TCL_STATIC);
                     free(indent);
-	            return TCL_ERROR;
+                    return TCL_ERROR;
                 }
+                ++indent_ptr;
+                ++code_ptr;
             }
         }
     }

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -85,7 +85,7 @@ static int
 tohil_TclObjIsNoneSentinel(Tcl_Obj *obj, const char *sentinel)
 {
     char *tclString = Tcl_GetString(obj);
-    if(sentinel == NULL)
+    if (sentinel == NULL)
         sentinel = TOHIL_NONE_SENTINEL;
     return (STREQU(tclString, sentinel));
 }
@@ -133,9 +133,15 @@ static int tohil_UndentPython(Tcl_Interp *interp, char *string) {
 
     // look for indent
     while (*code_ptr) {
-        // skip blank lines;
-        if(*code_ptr == '\n') {
+        // skip blank lines
+        if (*code_ptr == '\n') {
             ++code_ptr;
+            indent_ptr = indent;
+            continue;
+        }
+        // Even on Windows
+        if (code_ptr[0] == '\r' && code_ptr[1] == '\n') {
+            code_pter += 2;
             indent_ptr = indent;
             continue;
         }
@@ -150,7 +156,7 @@ static int tohil_UndentPython(Tcl_Interp *interp, char *string) {
     }
 
     // Empty code block, so just pass it back unchanged.
-    if(!seen_code) {
+    if (!seen_code) {
         free(indent);
         return TCL_OK;
     }
@@ -162,18 +168,18 @@ static int tohil_UndentPython(Tcl_Interp *interp, char *string) {
     // new newline.
     //
     char *working_ptr = string;
-    while(*code_ptr) {
+    while (*code_ptr) {
         char c = *working_ptr++ = *code_ptr++;
-        if(c == '\n') {
+        if (c == '\n') {
             indent_ptr = indent;
-            while(*indent_ptr && *code_ptr) {
+            while (*indent_ptr && *code_ptr) {
                 // Look for mismatches
-                if(*indent_ptr != *code_ptr) {
+                if (*indent_ptr != *code_ptr) {
                     // Fast forward to end of line
-                    while(*code_ptr != '\n' && isspace(*code_ptr))
+                    while (*code_ptr != '\n' && isspace(*code_ptr))
                         code_ptr++;
                     // Mismatch on blank line, ignore
-                    if(*code_ptr == '\n')
+                    if (!*code_ptr || *code_ptr == '\n')
                         break;
                     Tcl_SetResult(interp, "can't undent Python block (possibly mixed spaces and tabs)", TCL_STATIC);
                     free(indent);
@@ -886,7 +892,7 @@ TohilCall_Cmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *cons
     PyObject *pMainModule = PyImport_AddModule("__main__");
     if (pMainModule == NULL) {
         Tcl_DStringFree(&objandfn_ds);
-        if(nonevalue) Tcl_DStringFree(&nonevalue_ds);
+        if (nonevalue) Tcl_DStringFree(&nonevalue_ds);
         return Tohil_ReturnExceptionToTcl(interp, "unable to add module __main__ to python interpreter");
     }
 
@@ -903,7 +909,7 @@ TohilCall_Cmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *cons
         if (pObjStr == NULL) {
             Py_DECREF(pObjParent);
             Tcl_DStringFree(&objandfn_ds);
-            if(nonevalue) Tcl_DStringFree(&nonevalue_ds);
+            if (nonevalue) Tcl_DStringFree(&nonevalue_ds);
             return Tohil_ReturnExceptionToTcl(interp, "failed unicode translation of call function in python interpreter");
         }
 
@@ -912,7 +918,7 @@ TohilCall_Cmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *cons
         Py_DECREF(pObjParent);
         if (pObj == NULL) {
             Tcl_DStringFree(&objandfn_ds);
-            if(nonevalue) Tcl_DStringFree(&nonevalue_ds);
+            if (nonevalue) Tcl_DStringFree(&nonevalue_ds);
             return Tohil_ReturnExceptionToTcl(interp, "failed to find dotted attribute in python interpreter");
         }
 
@@ -939,7 +945,7 @@ TohilCall_Cmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *cons
         char errorString[CALL_ERROR_STRING_SIZE];
         snprintf(errorString, CALL_ERROR_STRING_SIZE, "name '%.200s' is not defined.", objandfn);
         Tcl_DStringFree(&objandfn_ds);
-        if(nonevalue) Tcl_DStringFree(&nonevalue_ds);
+        if (nonevalue) Tcl_DStringFree(&nonevalue_ds);
         PyErr_SetString(PyExc_NameError, errorString);
         return Tohil_ReturnExceptionToTcl(interp, "failed to find object/function in python interpreter");
     }
@@ -974,7 +980,7 @@ TohilCall_Cmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *cons
         /* Steals a reference */
         PyTuple_SET_ITEM(pArgs, i - objStart, curarg);
     }
-    if(nonevalue) Tcl_DStringFree(&nonevalue_ds);
+    if (nonevalue) Tcl_DStringFree(&nonevalue_ds);
 
     PyObject *pRet = PyObject_Call(pFn, pArgs, kwObj);
     Py_DECREF(pFn);

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -155,7 +155,7 @@ static int tohil_UndentPython(Tcl_Interp *interp, char *string) {
     }
 
     // walk string deleting indent on every line
-    char *working_ptr = indent;
+    char *working_ptr = string;
     while(*code_ptr) {
         char c = *working_ptr++ = *code_ptr++;
         if(c == '\n') {

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -141,7 +141,7 @@ static int tohil_UndentPython(Tcl_Interp *interp, char *string) {
         }
         // Even on Windows
         if (code_ptr[0] == '\r' && code_ptr[1] == '\n') {
-            code_pter += 2;
+            code_ptr += 2;
             indent_ptr = indent;
             continue;
         }

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -171,7 +171,7 @@ static int tohil_UndentPython(Tcl_Interp *interp, char *string) {
                 if(*indent_ptr != *code_ptr) {
                     // Fast forward to end of line
                     while(*code_ptr != '\n' && isspace(*code_ptr))
-			code_ptr++;
+                        code_ptr++;
                     // Mismatch on blank line, ignore
                     if(*code_ptr == '\n')
                         break;

--- a/tests/tohil.test
+++ b/tests/tohil.test
@@ -55,6 +55,34 @@ test tohil_exec-1.6 {exec invoking python invoking tcl} \
 	-body {catch {tohil::exec "tohil.eval('nonesuch')"} catchResult catchDict; return [lindex [dict get $catchDict -errorcode] 1]} \
 	-result TclError
 
+test tohil_exec-1.7 {exec with indented code} \
+	-body {
+		tohil::exec {
+			a = 5
+		}
+	}
+
+test tohil_exec-1.8 {exec with indented code and mismatched spaces} \
+	-body {
+		tohil::exec {
+			a = 5
+		       b = 5
+		}
+	} \
+	-returnCodes error \
+	-result {can't undent Python block (possibly mixed spaces and tabs)}
+
+# Note that the blank line in the next test contains several spaces to try and trip up the undenter
+# this is deliberate, don't edit them out.
+test tohil_exec-1.9 {exec with indented code and blank lines} \
+	-body {
+		tohil::exec {
+			a = 5
+                      
+			b = 5
+		}
+	}
+
 # =========
 # tohil::import
 # =========

--- a/tests/tohil.test
+++ b/tests/tohil.test
@@ -83,6 +83,35 @@ test tohil_exec-1.9 {exec with indented code and blank lines} \
 		}
 	}
 
+test tohil_exec-1.10 {exec with indent that is a mix of tabs and spaces} \
+	-body {
+		tohil::exec {
+		    a = 5
+		    b = 10
+		}
+	}
+
+test tohil_exec-1.11 {exec with an indented if statement} \
+	-body {
+		tohil::exec {
+			a = 5
+			if a > 10:
+				b = a
+			else:
+				b = 5
+		}
+	}
+
+# Note that the carriage returns at the end of lines in the following test are intentional
+# to test parsing of Windows format files.
+test tohil_exec-1.12 {exec with carriage returns} \
+	-body {
+		tohil::exec {
+			a = 5
+		}
+	}
+
+
 # =========
 # tohil::import
 # =========

--- a/tests/tohil.test
+++ b/tests/tohil.test
@@ -108,6 +108,8 @@ test tohil_exec-1.12 {exec with carriage returns} \
 	-body {
 		tohil::exec {
 			a = 5
+			
+			b = 5
 		}
 	}
 


### PR DESCRIPTION
Fix for #48 "Running multiple lines of python via tohil::exec/eval is a bit clunky"

The un-indenter can handle mixed spaces and tabs but only if the combination of spaces and tabs is identical on every non-blank line. It makes no assumptions as to tab-stop settings, it just requires the exact same combination as the first indented line.

It does not apply to tohil::eval calls.

It treats all unicode multibyte sequences as non-blank and copies them verbatim.