### PR TITLE
Fix building against Python 3.7 with nix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,8 @@ if test "$need_python_config" = "1"; then
         PYTHON_LIB_DIR="`$PYTHON_CONFIG --exec-prefix`/lib"
         AC_MSG_RESULT([using python3-config-deduced python lib dir of... "$PYTHON_LIB_DIR"])
     fi
+    PYTHON_VERSION="$PYTHON_VERSION`$PYTHON_CONFIG --abiflags`"
+    AC_MSG_RESULT([overriding python version to... "$PYTHON_VERSION"])
 fi
 
 AC_SUBST(PYTHON_INCLUDES)

--- a/configure.ac
+++ b/configure.ac
@@ -113,8 +113,11 @@ if test "$need_python_config" = "1"; then
         PYTHON_LIB_DIR="`$PYTHON_CONFIG --exec-prefix`/lib"
         AC_MSG_RESULT([using python3-config-deduced python lib dir of... "$PYTHON_LIB_DIR"])
     fi
-    PYTHON_VERSION="$PYTHON_VERSION`$PYTHON_CONFIG --abiflags`"
-    AC_MSG_RESULT([overriding python version to... "$PYTHON_VERSION"])
+    PYTHON_ABIFLAGS="`$PYTHON_CONFIG --abiflags`"
+    if test "$PYTHON_ABIFLAGS" != ""; then
+		PYTHON_VERSION="$PYTHON_VERSION$PYTHON_ABIFLAGS"
+		AC_MSG_RESULT([adding abiflags, python version is now... "$PYTHON_VERSION"])
+	fi
 fi
 
 AC_SUBST(PYTHON_INCLUDES)


### PR DESCRIPTION
Nix passes 3.7 as its version, not 3.7m. We can get at the m with
--abiflags, though. This ensures that when building the Tcl .so, we
provide the proper -l flag.

I'm not so good with autoconf, so this is probably not the ideal way to implement such a fix. @lehenbauer do you have a better place to put this?