### PR TITLE
Issue 63 rename interp

### DIFF
--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -284,7 +284,6 @@ from tohil._tohil import (
     exists,
     expr,
     getvar,
-    interp,
     setvar,
     subst,
     unset,


### PR DESCRIPTION
Tohil stored a Python capsule in dunder-main.interp and you could make Python crash by doing like "interp = ''" before importing tohil.  This renames interp to _tohil_interp, which is way less likely to have a conflict.

We also do a bit of cleanup on the name of the Python capsule itself.

Fixes issue #63.
