### PR TITLE
Thread state handling improvements aka bug and crash fixes when using Tohil/Python from multiple Tcl interpreters

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so that we create the export library with the dll.
 #-----------------------------------------------------------------------
 
-AC_INIT([tohil],[4.2.0])
+AC_INIT([tohil],[4.2.1])
 
 #--------------------------------------------------------------------
 # Call TEA_INIT as the first TEA_ macro to set up initial vars.

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -676,16 +676,21 @@ tohil_restore_subinterp(PyThreadState *prior)
 }
 
 // tohil_tcl_return - you call this routine when you are returning to
-//   tcl after having done some work.
+//   tcl after having done some work.  it restores the python thread
+//   state and returns the specified Tcl return code.
 //
-//   it checks to make sure
+//   it checks to make sure you aren't trying to return to Tcl with an
+//   unhandled Python exception, which if you did and we didn't check,
+//   it would just cause the next innocent Python thing attempted to get
+//   fingered for the error.
 //
 static int
 tohil_tcl_return(Tcl_Interp *interp, PyThreadState *prior, int tcl_result)
 {
     // check for an unhandled python exception -- that should not happen
+    // and if it does it indicates a bug in Tohil.
     if (PyErr_Occurred() != NULL) {
-        return Tohil_ReturnExceptionToTcl(interp, prior, "Tohil C code returned to Tcl with an unprocessed Python exception");
+        return Tohil_ReturnExceptionToTcl(interp, prior, "Tohil C code returned to Tcl with an unhandled Python exception");
     }
 
     tohil_restore_subinterp(prior);

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -883,6 +883,17 @@ tohil_swap_subinterp(Tcl_Interp *interp)
 //  that it's the parent, so as not to delete it if our
 //  interpreter gets deleted.
 //
+//  When a new subinterpreter is created, Python switches the thread state
+//  to the new interpreter.  Because of this, tohil_setup_subinterp returns
+//  the Python thread state that was active when it was called, and
+//  the caller is expected to keep track of that thread state pointer
+//  and swap it back in when it's done.
+//
+//  The one exception to this is in tohil_mod_exec where the code knows
+//  that the Python interpreter being created is the parent Python
+//  interpreter, i.e. not a subinterpreter, and there is no prior thread stated
+//  to save or restore.
+//
 static PyThreadState *
 tohil_setup_subinterp(Tcl_Interp *interp, enum SubinterpType subtype)
 {

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -791,6 +791,7 @@ Tohil_ReturnExceptionToTcl(Tcl_Interp *interp, PyThreadState *prior, char *descr
     Tcl_SetObjErrorCode(interp, pyObjToTcl(interp, PyTuple_GET_ITEM(pExceptionResult, 0)));
     Tcl_AppendObjToErrorInfo(interp, pyObjToTcl(interp, PyTuple_GET_ITEM(pExceptionResult, 1)));
     Py_DECREF(pExceptionResult);
+    tohil_restore_subinterp(prior);
     return TCL_ERROR;
 }
 

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -858,9 +858,13 @@ tohil_restore_subinterp(PyThreadState *prior)
     // that code deal with if you're swapping to the thread state
     // that's already current, but from inspection it looks to do
     // a lot so we try to optimize here.  if we're wrong then simplify here.
-    PyThreadState *current = PyThreadState_Get();
+
+    // at startup PyThreadState_Get() can return NULL, don't switch
+    // the threadstate to NULL; just go on
     if (prior == NULL)
-        return current;
+        return;
+
+    PyThreadState *current = PyThreadState_Get();
 
     if (prior != current) {
         PyThreadState_Swap(prior);

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -4545,7 +4545,7 @@ static struct PyModuleDef TohilModule = {
 int
 Tohil_Init(Tcl_Interp *interp)
 {
-    static PyThreadState *prior = NULL;
+    PyThreadState *prior = NULL;
     // printf("Tohil_Init\n");
 
     if (Tcl_InitStubs(interp, "8.6", 0) == NULL)

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -1295,8 +1295,9 @@ TohilTclObj_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
             return NULL;
     }
 
-    // grab pointer to tcl interp out of tclobj type's dictionary
-    PyObject *pCap = PyDict_GetItemString(type->tp_dict, "_interp");
+    // grab pointer to tcl interp
+    PyObject *main_module = PyImport_AddModule("__main__");
+    PyObject *pCap = PyObject_GetAttrString(main_module, TOHIL_TCL_INTERP_STASH_NAME);
     assert(pCap != NULL);
     Tcl_Interp *interp = PyCapsule_GetPointer(pCap, TCL_TCL_INTERP_CAPSULE_NAME);
 
@@ -4764,16 +4765,6 @@ tohil_mod_exec(PyObject *m)
     // and need to talk to tcl
     pCap = PyCapsule_New(interp, TCL_TCL_INTERP_CAPSULE_NAME, NULL);
     if (PyObject_SetAttrString(m, TOHIL_TCL_INTERP_STASH_NAME, pCap) == -1) {
-        Py_DECREF(pCap);
-        goto fail;
-    }
-    // stash capsule in the tclobj datatype's dictionary
-    if (PyDict_SetItemString(TohilTclObjType.tp_dict, "_interp", pCap) == -1) {
-        Py_DECREF(pCap);
-        goto fail;
-    }
-    // stash capsule in the tcldict datatype's dictionary
-    if (PyDict_SetItemString(TohilTclDictType.tp_dict, "_interp", pCap) == -1) {
         Py_DECREF(pCap);
         goto fail;
     }

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -4435,7 +4435,7 @@ PythonCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const ob
 
     /* Create argument tuple (objv1, ..., objvN) */
     if (!(args = PyTuple_New(objc - 1)))
-        return TCL_ERROR;
+        return tohil_tcl_return(interp, prior, TCL_ERROR);
 
     for (i = 0; i < (objc - 1); i++) {
         Tcl_DString ds;
@@ -4443,7 +4443,7 @@ PythonCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const ob
         Tcl_DStringFree(&ds);
         if (!s) {
             Py_DECREF(args);
-            return TCL_ERROR;
+            return tohil_tcl_return(interp, prior, TCL_ERROR);
         }
         PyTuple_SET_ITEM(args, i, s);
     }


### PR DESCRIPTION
For every function of the tohil Tcl-side that does something with Python such as exec'ing, eval'ing, importing, call'ing, or invoking a Tcl/Python callback, don't just switch to the threadstate for that tcl interpreter's corresponding Python interpreter, but also keep track of what the threadstate is when those functions are first called, and switch it back right before they return.

To do this we
* made tohil_setup_subinterp return the prior python thread state.
* extended the calls to tohil_setup_subinterp in Tohil_Init to keep the prior thread state and, prior to returning, to restore it.
* added a PyThreadState parameter to each ot tohil_tcl_return, Tohil_ReturnTclError, Tohil_ReturnStartupExceptionToTcl, and Tohil_ReturnExceptionToTcl and code for them to either pass along or restore the threadstate at the right moment after all manipulation of the relevant Python subinterpreter that was being used is complete.
* fixed a bug where we were storing a pointer to the Tcl interpreter in our tclobj and tcldict datatypes.  We changed it to use the same safe method to find the current Tcl interpreter that we use elsewhere, simplifying the code.