### PR TITLE
Set ::argv globals for Tcl if Python has anything in sys.argv

### DIFF
--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -296,24 +296,27 @@ from tohil._tohil import (
     __version__,
 )
 
-###
-### tcl proc importer and trampoline
-###
-
-tcl_init = """
-proc safe_info_default {proc arg} {
-    if {[info default $proc $arg var] == 1} {
-        return [list 1 $var]
+def _init_tcl_env():
+    tcl_init = """
+    proc safe_info_default {proc arg} {
+        if {[info default $proc $arg var] == 1} {
+            return [list 1 $var]
+        }
+        return [list 0 ""]
     }
-    return [list 0 ""]
-}
-"""
+    """
 
-_tohil.eval(tcl_init)
+    _tohil.eval(tcl_init)
+
+_init_tcl_env()
 
 def tclvar(tcl_var_name, **kwargs):
     return tclobj(var=tcl_var_name, **kwargs)
 
+
+###
+### tcl proc importer and trampoline
+###
 
 def info_args(proc):
     """wrapper for 'info args'"""

--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -304,9 +304,20 @@ def _init_tcl_env():
         }
         return [list 0 ""]
     }
+
+    # Clear in case we're being reloaded
+    unset -nocomplain ::argc ::argv ::argv0
     """
 
     _tohil.eval(tcl_init)
+    if _sys.argv:
+        # Set up argv globals as if we were tclsh
+        argv0 = _sys.argv[0]
+        argv = _sys.argv[1:]
+        argc = len(argv)
+        _tohil.call("set", "::argv0", argv0)
+        _tohil.call("set", "::argv", argv)
+        _tohil.call("set", "::argc", argc)
 
 _init_tcl_env()
 

--- a/tests/test_arg_globals.py
+++ b/tests/test_arg_globals.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+import unittest
+
+import tohil
+
+
+class TestArgGlobals(unittest.TestCase):
+    def test_empty_argv(self):
+        sys.argv = []
+        importlib.reload(tohil)
+        self.assertEqual(tohil.call("info", "exists", "::argv"), 0)
+        self.assertEqual(tohil.call("info", "exists", "::argv0"), 0)
+        self.assertEqual(tohil.call("info", "exists", "::argc"), 0)
+
+    def test_argv_blank(self):
+        sys.argv = [""]
+        importlib.reload(tohil)
+        self.assertEqual(tohil.call("set", "::argv", to=list), [])
+        self.assertEqual(tohil.call("set", "::argv0"), "")
+        self.assertEqual(tohil.call("set", "::argc"), 0)
+
+    def test_argv_multiple(self):
+        sys.argv = ["script.py", "arg1", "arg2"]
+        importlib.reload(tohil)
+        self.assertEqual(tohil.call("set", "::argv", to=list), sys.argv[1:])
+        self.assertEqual(tohil.call("set", "::argv0"), "script.py")
+        self.assertEqual(tohil.call("set", "::argc"), 2)


### PR DESCRIPTION
Helps Tcl behave like it's running in a shell.