### PR TITLE
Fix a couple issues with setting Tcl's ::arg* vars

### DIFF
--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -304,13 +304,12 @@ def _init_tcl_env():
         }
         return [list 0 ""]
     }
-
-    # Clear in case we're being reloaded
-    unset -nocomplain ::argc ::argv ::argv0
     """
 
     _tohil.eval(tcl_init)
-    if _sys.argv:
+    # In python3.8 and above, argv falls back to [""], but before that it would
+    # be just [] here (since we're not setting it ourselves).
+    if _sys.argv and _sys.argv != [""]:
         # Set up argv globals as if we were tclsh
         argv0 = _sys.argv[0]
         argv = _sys.argv[1:]

--- a/tests/test_arg_globals.py
+++ b/tests/test_arg_globals.py
@@ -6,7 +6,11 @@ import tohil
 
 
 class TestArgGlobals(unittest.TestCase):
+    def setUp(self):
+        tohil.eval("unset -nocomplain ::argv ::argv0 ::argc")
+
     def test_empty_argv(self):
+        # This can occur naturally, but only before python3.8
         sys.argv = []
         importlib.reload(tohil)
         self.assertEqual(tohil.call("info", "exists", "::argv"), 0)
@@ -14,11 +18,13 @@ class TestArgGlobals(unittest.TestCase):
         self.assertEqual(tohil.call("info", "exists", "::argc"), 0)
 
     def test_argv_blank(self):
+        # This is python's 3.8+ fallback behavior and can generally be equated
+        # to "nothing was set"
         sys.argv = [""]
         importlib.reload(tohil)
-        self.assertEqual(tohil.call("set", "::argv", to=list), [])
-        self.assertEqual(tohil.call("set", "::argv0"), "")
-        self.assertEqual(tohil.call("set", "::argc"), 0)
+        self.assertEqual(tohil.call("info", "exists", "::argv"), 0)
+        self.assertEqual(tohil.call("info", "exists", "::argv0"), 0)
+        self.assertEqual(tohil.call("info", "exists", "::argc"), 0)
 
     def test_argv_multiple(self):
         sys.argv = ["script.py", "arg1", "arg2"]


### PR DESCRIPTION
1. In python 3.8+, sys.argv defaults to [""] when not otherwise set (I
   had wrongly assumed it would always be [])
2. If Tcl's ::arg* vars were already set naturally, tohil could clear
   them improperly.

EP-90
