### PR TITLE
python3.6 compatability check for argv

### DIFF
--- a/pysrc/tohil/__init__.py
+++ b/pysrc/tohil/__init__.py
@@ -307,6 +307,9 @@ def _init_tcl_env():
     """
 
     _tohil.eval(tcl_init)
+    # In python3.6 if there are no arguments, then sys has no argv attribute at all
+    if not hasattr(_sys, 'argv'):
+        _sys.argv = []
     # In python3.8 and above, argv falls back to [""], but before that it would
     # be just [] here (since we're not setting it ourselves).
     if _sys.argv and _sys.argv != [""]:


### PR DESCRIPTION
In python 3.6, it looks like `sys.argv` doesn't get set at all when there are no arguments.  This causes a `module 'sys' has no attribute 'argv'` error when checking for arguments.  We now explicitly check for the attribute and if not set, assign it to the empty array and emulate python3.7 behaviour.