### PR TITLE
Fix floating point platform discrepancies; replace deprecated call to Py_SetProgramName; Remove ref to internal python type

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies	
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y python3 python3-dev python3-pip tcl8.6-dev
+          sudo apt-get install -y python3 python3-dev python3.10-dev python3-pip tcl8.6-dev
           sudo pip3 install hypothesis
 
       - name: configure	

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies	
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y python3 python3-dev python3.10-dev python3-pip tcl8.6-dev
+          sudo apt-get install -y python3 python3-dev python3.12-dev python3-pip tcl8.6-dev
           sudo pip3 install hypothesis
 
       - name: configure	

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: configure	
         run: |
           autoreconf
-          ./configure --with-tcl=/usr/lib/tcl8.6 --with-python-include=/usr/include/python3.8 --with-python-lib=/usr/lib --with-python-version=3.8
+          ./configure --with-tcl=/usr/lib/tcl8.6 --with-python-include=/usr/include/python3.12 --with-python-lib=/usr/lib --with-python-version=3.12
 
       - name: make	
         run: |

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2673,25 +2673,25 @@ Tohil_TD_items_iternext(Tohil_TD_IterObj *self)
 }
 
 static PyObject *
-Tohil_TD_iter_repr(_PyDictViewObject *dv)
+Tohil_TD_iter_repr(Tohil_TD_IterObj *self)
 {
     PyObject *seq;
     PyObject *result = NULL;
     Py_ssize_t rc;
 
-    rc = Py_ReprEnter((PyObject *)dv);
+    rc = Py_ReprEnter((PyObject *)self);
     if (rc != 0) {
         return rc > 0 ? PyUnicode_FromString("...") : NULL;
     }
-    seq = PySequence_List((PyObject *)dv);
+    seq = PySequence_List((PyObject *)self);
     if (seq == NULL) {
         goto Done;
     }
-    result = PyUnicode_FromFormat("%s(%R)", Py_TYPE(dv)->tp_name, seq);
+    result = PyUnicode_FromFormat("%s(%R)", Py_TYPE(self)->tp_name, seq);
     Py_DECREF(seq);
 
 Done:
-    Py_ReprLeave((PyObject *)dv);
+    Py_ReprLeave((PyObject *)self);
     return result;
 }
 

--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2998,7 +2998,7 @@ tclobj_nb_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
 
         case Truediv:
             if (doubleW == 0.0) {
-                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
                 return NULL;
             }
             return PyFloat_FromDouble(doubleV / doubleW);
@@ -3007,7 +3007,7 @@ tclobj_nb_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             double mod, floordiv;
 
             if (doubleW == 0.0) {
-                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
                 return NULL;
             }
             _float_div_mod(doubleV, doubleW, &floordiv, &mod);
@@ -3034,7 +3034,7 @@ tclobj_nb_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
 
         case Divmod:
             if (doubleW == 0.0) {
-                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
                 return NULL;
             }
             _float_div_mod(doubleV, doubleW, &quotient, &remainder);
@@ -3279,7 +3279,7 @@ tclobj_nb_inplace_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
 
         case Truediv:
             if (doubleW == 0.0) {
-                PyErr_SetString(PyExc_ZeroDivisionError, "float division by zero");
+                PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
                 return NULL;
             }
             Tcl_SetDoubleObj(writeObj, doubleV / doubleW);

--- a/tests/tohil.test
+++ b/tests/tohil.test
@@ -403,10 +403,10 @@ test modules-1.2 {zlib module} \
 test modules-1.3 {datetime module} \
 	-body {
 		tohil::import datetime
-		tohil::exec {def a(): return datetime.datetime.utcfromtimestamp(0).isoformat()}
+		tohil::exec {def a(): return datetime.datetime.fromtimestamp(0, datetime.UTC).isoformat()}
 		tohil::call a
 	} \
-	-result "1970-01-01T00:00:00"
+	-result "1970-01-01T00:00:00+00:00"
 
 test module-1.4 {sqlite3 module} \
 	-body {


### PR DESCRIPTION
## Resolve discrepancies in certain floating point calculations between x86 and ARM

* This update aligns Tohil's tclobj math behavior for both floor division (//) and remainder (%) operations with CPython, eliminating small platform-dependent calculation differences, for example between x86 and ARM.  It applies consistently to expressions (e.g., a // b, a % b) and augmented assignments (e.g., a //= b, a %= b).

## Use PyConfig in place of deprecated Py_SetProgramName

* In Tohil_Init, use Python's PyConfig means of configuring the Python interpreter in place of the deprecated Py_SetProgramName.
* Also when Tcl is the parent, use PyConfig's mechanism for telling Python not to install signal handlers.

This should be compatible with Python versions back to and including 3.8.

## Remove ref to internal python type in Tohil_TD_iter_repr

* Make Tohil_TD_iter_repr declare its proper argument type, the actual iterator type that goes with it, Tohil_TD_IterObj.
* Conform Tohil_TD_iter_repr to reference its object using the standard "self" name for readability and consistency.