### PR TITLE
Boost declaration to the beginning of the block.

### DIFF
--- a/generic/tohil.c
+++ b/generic/tohil.c
@@ -2987,6 +2987,7 @@ tclobj_nb_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
         }
 
         switch (operator) {
+            double mod, floordiv;
         case Add:
             return PyFloat_FromDouble(doubleV + doubleW);
 
@@ -3004,8 +3005,6 @@ tclobj_nb_binop(PyObject *v, PyObject *w, enum tclobj_op operator)
             return PyFloat_FromDouble(doubleV / doubleW);
 
         case Floordiv:
-            double mod, floordiv;
-
             if (doubleW == 0.0) {
                 PyErr_SetString(PyExc_ZeroDivisionError, "division by zero");
                 return NULL;


### PR DESCRIPTION
The declaration was an issue because it was after a label (switch case) and that is an error for some combinations of gcc options. Technically not legal C, I don't think. Anyway, moved it to the beginning of the block.